### PR TITLE
feat: websocket 의존성 추가 및  STOMP config 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/oronaminc/join/global/config/WebSocketConfig.java
+++ b/src/main/java/com/oronaminc/join/global/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.oronaminc.join.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. WebSocketConfig.java

`global/config/WebSocketconfig.java`

#### 2. STOMP 환경 설정

- websocket 의존성 추가
- STOMP config 설정 추가


<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- WebSocket STOMP 설정(WebSocketConfig.java)을 추가했습니다.
- `registerStompEndpoints`메서드의 `registry.setAllowedOriginPatterns("*")`설정은 모든 클라이언트의 연결을 허용하기 위해 와일드 카드를 사용했습니다. 우선 개발 단계에서의 편의를 위한 설정입니다.
- 추후 보안상 잠재적인 위험을 가질 수 있기에 배포 시에는 실제 도메인 주소를 명시적으로 지정해야 합니다.


<br/>
