### PR TITLE
feat: 수정, 삭제, 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/oronaminc/join/answer/dao/AnswerRepository.java
+++ b/src/main/java/com/oronaminc/join/answer/dao/AnswerRepository.java
@@ -1,0 +1,12 @@
+package com.oronaminc.join.answer.dao;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.oronaminc.join.answer.domain.Answer;
+import com.oronaminc.join.question.domain.Question;
+
+public interface AnswerRepository extends JpaRepository<Answer,Long> {
+    void deleteByQuestionIn(List<Question> questions);
+}

--- a/src/main/java/com/oronaminc/join/answer/service/AnswerService.java
+++ b/src/main/java/com/oronaminc/join/answer/service/AnswerService.java
@@ -1,0 +1,20 @@
+package com.oronaminc.join.answer.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.oronaminc.join.answer.dao.AnswerRepository;
+import com.oronaminc.join.question.domain.Question;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerService {
+    private final AnswerRepository answerRepository;
+
+    public void deleteByQuestionList(List<Question> questions) {
+        answerRepository.deleteByQuestionIn(questions);
+    }
+}

--- a/src/main/java/com/oronaminc/join/document/dao/DocumentRepository.java
+++ b/src/main/java/com/oronaminc/join/document/dao/DocumentRepository.java
@@ -8,4 +8,5 @@ import com.oronaminc.join.document.domain.Document;
 
 public interface DocumentRepository extends JpaRepository<Document, Long> {
     Optional<Document> findByRoomId(Long roomId);
+    void deleteByRoomId(Long roomId);
 }

--- a/src/main/java/com/oronaminc/join/document/service/DocumentService.java
+++ b/src/main/java/com/oronaminc/join/document/service/DocumentService.java
@@ -19,4 +19,8 @@ public class DocumentService {
         return documentRepository.findByRoomId(roomId)
                 .orElseThrow(() -> new ErrorException(NOT_FOUND_FILE));
     }
+
+    public void deleteByRoomId(Long roomId) {
+        documentRepository.deleteByRoomId(roomId);
+    }
 }

--- a/src/main/java/com/oronaminc/join/emoji/repository/EmojiRepository.java
+++ b/src/main/java/com/oronaminc/join/emoji/repository/EmojiRepository.java
@@ -7,4 +7,5 @@ import com.oronaminc.join.emoji.domain.TargetType;
 
 public interface EmojiRepository extends JpaRepository<Emoji, Long> {
     Integer countByTargetIdAndTargetType(Long targetId, TargetType targetType);
+    void deleteByTargetTypeAndTargetId(TargetType targetType, Long targetId);
 }

--- a/src/main/java/com/oronaminc/join/emoji/service/EmojiService.java
+++ b/src/main/java/com/oronaminc/join/emoji/service/EmojiService.java
@@ -15,4 +15,8 @@ public class EmojiService {
     public Integer countRoomEmoji(Long roomId) {
         return emojiRepository.countByTargetIdAndTargetType(roomId, TargetType.ROOM);
     }
+
+    public void deleteByRoomEmoji(Long roomId) {
+        emojiRepository.deleteByTargetTypeAndTargetId(TargetType.ROOM, roomId);
+    }
 }

--- a/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
@@ -13,10 +13,11 @@ public enum ErrorCode {
     UNAUTHORIZED_MEMBER("AUTH-002", "인증되지 않은 회원입니다.", UNAUTHORIZED),
 
     NOT_FOUND_ROOM("ROOM-001", "존재하지 않는 발표방입니다.", NOT_FOUND),
+    BAD_REQUEST_ROOM_STARTED("ROOM-002", "시작 상태의 발표방은 수정 및 삭제할 수 없습니다.", BAD_REQUEST),
 
     NOT_FOUND_PARTICIPANT("PARTICIPANT-001", "발표방에 존재하지 않는 회원입니다.", NOT_FOUND),
     UNAUTHORIZED_TEAM_GUEST("PARTICIPANT-002", "게스트는 팀이 될 수 없습니다.", UNAUTHORIZED),
-    UNAUTHORIZED_UPDATE("PARTICIPANT-003", "발표방 수정 권한이 없습니다.", UNAUTHORIZED),
+    UNAUTHORIZED_UPDATE_AND_DELETE("PARTICIPANT-003", "발표방 수정 및 삭제 권한이 없습니다.", UNAUTHORIZED),
 
     FILE_UPLOAD_FAILED("FILE-001", "파일 업로드에 실패하였습니다.", INTERNAL_SERVER_ERROR),
     NOT_FOUND_FILE("FILE-002", "존재하지 않는 파일입니다.",  NOT_FOUND);

--- a/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 
     NOT_FOUND_ROOM("ROOM-001", "존재하지 않는 발표방입니다.", NOT_FOUND),
     BAD_REQUEST_ROOM_STARTED("ROOM-002", "시작 상태의 발표방은 수정 및 삭제할 수 없습니다.", BAD_REQUEST),
+    BAD_REQUEST_UPDATE_STATUS("ROOM-003", "변경할 수 없는 상태입니다.", BAD_REQUEST),
 
     NOT_FOUND_PARTICIPANT("PARTICIPANT-001", "발표방에 존재하지 않는 회원입니다.", NOT_FOUND),
     UNAUTHORIZED_TEAM_GUEST("PARTICIPANT-002", "게스트는 팀이 될 수 없습니다.", UNAUTHORIZED),

--- a/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 
     NOT_FOUND_PARTICIPANT("PARTICIPANT-001", "발표방에 존재하지 않는 회원입니다.", NOT_FOUND),
     UNAUTHORIZED_TEAM_GUEST("PARTICIPANT-002", "게스트는 팀이 될 수 없습니다.", UNAUTHORIZED),
+    UNAUTHORIZED_UPDATE("PARTICIPANT-003", "발표방 수정 권한이 없습니다.", UNAUTHORIZED),
 
     FILE_UPLOAD_FAILED("FILE-001", "파일 업로드에 실패하였습니다.", INTERNAL_SERVER_ERROR),
     NOT_FOUND_FILE("FILE-002", "존재하지 않는 파일입니다.",  NOT_FOUND);

--- a/src/main/java/com/oronaminc/join/participant/dao/ParticipantRepository.java
+++ b/src/main/java/com/oronaminc/join/participant/dao/ParticipantRepository.java
@@ -58,4 +58,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
         """)
     Page<Participant> findByMemberIdAndParticipantTypeNot(Long memberId, ParticipantType pType,
         Pageable pageable);
+
+    void deleteByRoomId(Long roomId);
 }

--- a/src/main/java/com/oronaminc/join/participant/dao/ParticipantRepository.java
+++ b/src/main/java/com/oronaminc/join/participant/dao/ParticipantRepository.java
@@ -3,14 +3,15 @@ package com.oronaminc.join.participant.dao;
 import java.util.List;
 import java.util.Optional;
 
-import com.oronaminc.join.member.dto.ParticipantCountDto;
-import com.oronaminc.join.participant.domain.Participant;
-import com.oronaminc.join.participant.domain.ParticipantType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import com.oronaminc.join.member.dto.ParticipantCountDto;
+import com.oronaminc.join.participant.domain.Participant;
+import com.oronaminc.join.participant.domain.ParticipantType;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
@@ -57,5 +58,4 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
         """)
     Page<Participant> findByMemberIdAndParticipantTypeNot(Long memberId, ParticipantType pType,
         Pageable pageable);
-
 }

--- a/src/main/java/com/oronaminc/join/participant/service/ParticipantService.java
+++ b/src/main/java/com/oronaminc/join/participant/service/ParticipantService.java
@@ -78,4 +78,15 @@ public class ParticipantService {
             this.saveMemberParticipantByEmail(email, room, ParticipantType.TEAM);
         }
     }
+
+    public void validatePresenter(Long roomId, Long memberId) {
+        Participant presenter = this.getPresenter(roomId);
+        if (!presenter.getMember().getId().equals(memberId)) {
+            throw new ErrorException(UNAUTHORIZED_UPDATE_AND_DELETE);
+        }
+    }
+
+    public void deleteParticipantByRoomId(Long roomId) {
+        participantRepository.deleteByRoomId(roomId);
+    }
 }

--- a/src/main/java/com/oronaminc/join/participant/service/ParticipantService.java
+++ b/src/main/java/com/oronaminc/join/participant/service/ParticipantService.java
@@ -65,4 +65,17 @@ public class ParticipantService {
     public List<Participant> getTeam(Long roomId) {
         return participantRepository.findAllByRoomIdAndParticipantType(roomId, ParticipantType.TEAM);
     }
+
+    public void updateTeam(Room room, List<String> emails) {
+        List<Participant> team = this.getTeam(room.getId());
+        for (Participant participant : team) {
+            if (!emails.contains(participant.getMember().getEmail())) {
+                participantRepository.delete(participant);
+            }
+        }
+
+        for (String email : emails) {
+            this.saveMemberParticipantByEmail(email, room, ParticipantType.TEAM);
+        }
+    }
 }

--- a/src/main/java/com/oronaminc/join/question/dao/QuestionRepository.java
+++ b/src/main/java/com/oronaminc/join/question/dao/QuestionRepository.java
@@ -1,11 +1,11 @@
 package com.oronaminc.join.question.dao;
 
-import com.oronaminc.join.question.domain.Question;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import com.oronaminc.join.question.domain.Question;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
@@ -16,4 +16,8 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
         group by q.room.id
         """)
     List<Object[]> countByRoomIds(List<Long> roomIds);
+
+    List<Question> findByRoomId(Long roomId);
+
+    void deleteByRoomId(Long roomId);
 }

--- a/src/main/java/com/oronaminc/join/question/service/QuestionService.java
+++ b/src/main/java/com/oronaminc/join/question/service/QuestionService.java
@@ -1,20 +1,25 @@
 package com.oronaminc.join.question.service;
 
-import static com.oronaminc.join.global.exception.ErrorCode.NOT_FOUND_PARTICIPANT;
+import static com.oronaminc.join.global.exception.ErrorCode.*;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.oronaminc.join.answer.service.AnswerService;
 import com.oronaminc.join.global.exception.ErrorCode;
 import com.oronaminc.join.global.exception.ErrorException;
-import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.member.dao.MemberRepository;
+import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.participant.dao.ParticipantRepository;
+import com.oronaminc.join.question.dao.QuestionRepository;
 import com.oronaminc.join.question.domain.Question;
 import com.oronaminc.join.question.dto.QuestionCreateRequest;
 import com.oronaminc.join.question.mapper.QuestionMapper;
-import com.oronaminc.join.question.dao.QuestionRepository;
-import com.oronaminc.join.room.domain.Room;
 import com.oronaminc.join.room.dao.RoomRepository;
+import com.oronaminc.join.room.domain.Room;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +29,7 @@ public class QuestionService {
     private final RoomRepository roomRepository;
     private final MemberRepository memberRepository;
     private final ParticipantRepository participantRepository;
+    private final AnswerService answerService;
 
     public Question create(Long roomId, Long memberId, QuestionCreateRequest requestDto) {
 
@@ -44,4 +50,9 @@ public class QuestionService {
         return question;
     }
 
+    public void deleteByRoomId(Long roomId) {
+        List<Question> questions = questionRepository.findByRoomId(roomId);
+        answerService.deleteByQuestionList(questions);
+        questionRepository.deleteByRoomId(roomId);
+    }
 }

--- a/src/main/java/com/oronaminc/join/room/api/RoomController.java
+++ b/src/main/java/com/oronaminc/join/room/api/RoomController.java
@@ -1,11 +1,9 @@
 package com.oronaminc.join.room.api;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,8 +17,12 @@ import com.oronaminc.join.room.dto.CreateRoomResponse;
 import com.oronaminc.join.room.dto.JoinRoomRequest;
 import com.oronaminc.join.room.dto.JoinRoomResponse;
 import com.oronaminc.join.room.dto.RoomDetailResponse;
+import com.oronaminc.join.room.dto.RoomUpdateRequest;
 import com.oronaminc.join.room.service.RoomService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -63,5 +65,15 @@ public class RoomController {
     @ResponseStatus(HttpStatus.OK)
     public RoomDetailResponse getRoomDetail(@PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {
         return roomService.getRoomDetail(memberDetails.getId(), roomId);
+    }
+
+    @PatchMapping("/{roomId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateRoom(
+            @RequestBody @Valid RoomUpdateRequest roomUpdateRequest,
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        roomService.updateRoom(memberDetails.getId(), roomId, roomUpdateRequest);
     }
 }

--- a/src/main/java/com/oronaminc/join/room/api/RoomController.java
+++ b/src/main/java/com/oronaminc/join/room/api/RoomController.java
@@ -18,6 +18,7 @@ import com.oronaminc.join.room.dto.CreateRoomResponse;
 import com.oronaminc.join.room.dto.JoinRoomRequest;
 import com.oronaminc.join.room.dto.JoinRoomResponse;
 import com.oronaminc.join.room.dto.RoomDetailResponse;
+import com.oronaminc.join.room.dto.RoomUpdateInfoResponse;
 import com.oronaminc.join.room.dto.RoomUpdateRequest;
 import com.oronaminc.join.room.dto.RoomUpdateStatusRequest;
 import com.oronaminc.join.room.service.RoomService;
@@ -92,5 +93,14 @@ public class RoomController {
             @RequestBody RoomUpdateStatusRequest roomUpdateStatusRequest,
             @AuthenticationPrincipal MemberDetails memberDetails) {
         roomService.updateRoomStatus(memberDetails.getId(), roomId, roomUpdateStatusRequest);
+    }
+
+    @GetMapping("/{roomId}/update")
+    @ResponseStatus(HttpStatus.OK)
+    public RoomUpdateInfoResponse getUpdateInfo(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        return roomService.getRoomUpdateInfo(memberDetails.getId(), roomId);
     }
 }

--- a/src/main/java/com/oronaminc/join/room/api/RoomController.java
+++ b/src/main/java/com/oronaminc/join/room/api/RoomController.java
@@ -19,6 +19,7 @@ import com.oronaminc.join.room.dto.JoinRoomRequest;
 import com.oronaminc.join.room.dto.JoinRoomResponse;
 import com.oronaminc.join.room.dto.RoomDetailResponse;
 import com.oronaminc.join.room.dto.RoomUpdateRequest;
+import com.oronaminc.join.room.dto.RoomUpdateStatusRequest;
 import com.oronaminc.join.room.service.RoomService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -82,5 +83,14 @@ public class RoomController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteRoom(@PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {
         roomService.deleteRoom(memberDetails.getId(), roomId);
+    }
+
+    @PatchMapping("/{roomId}/status")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateRoomStatus(
+            @PathVariable Long roomId,
+            @RequestBody RoomUpdateStatusRequest roomUpdateStatusRequest,
+            @AuthenticationPrincipal MemberDetails memberDetails) {
+        roomService.updateRoomStatus(memberDetails.getId(), roomId, roomUpdateStatusRequest);
     }
 }

--- a/src/main/java/com/oronaminc/join/room/api/RoomController.java
+++ b/src/main/java/com/oronaminc/join/room/api/RoomController.java
@@ -2,6 +2,7 @@ package com.oronaminc.join.room.api;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -75,5 +76,11 @@ public class RoomController {
             @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         roomService.updateRoom(memberDetails.getId(), roomId, roomUpdateRequest);
+    }
+
+    @DeleteMapping("/{roomId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteRoom(@PathVariable Long roomId, @AuthenticationPrincipal MemberDetails memberDetails) {
+        roomService.deleteRoom(memberDetails.getId(), roomId);
     }
 }

--- a/src/main/java/com/oronaminc/join/room/domain/Room.java
+++ b/src/main/java/com/oronaminc/join/room/domain/Room.java
@@ -56,4 +56,8 @@ public class Room extends BaseEntity {
         this.endedAt = roomUpdateRequest.endDate().atTime(LocalTime.MAX);
         this.participantLimit = roomUpdateRequest.participantLimit();
     }
+
+    public void updateStatus(RoomStatus roomStatus) {
+        this.roomStatus = roomStatus;
+    }
 }

--- a/src/main/java/com/oronaminc/join/room/domain/Room.java
+++ b/src/main/java/com/oronaminc/join/room/domain/Room.java
@@ -1,8 +1,10 @@
 package com.oronaminc.join.room.domain;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import com.oronaminc.join.global.entity.BaseEntity;
+import com.oronaminc.join.room.dto.RoomUpdateRequest;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -47,4 +49,11 @@ public class Room extends BaseEntity {
 
     @Version
     private Integer version;
+
+    public void update(RoomUpdateRequest roomUpdateRequest) {
+        this.title = roomUpdateRequest.title();
+        this.description = roomUpdateRequest.description();
+        this.endedAt = roomUpdateRequest.endDate().atTime(LocalTime.MAX);
+        this.participantLimit = roomUpdateRequest.participantLimit();
+    }
 }

--- a/src/main/java/com/oronaminc/join/room/dto/RoomUpdateInfoResponse.java
+++ b/src/main/java/com/oronaminc/join/room/dto/RoomUpdateInfoResponse.java
@@ -1,0 +1,16 @@
+package com.oronaminc.join.room.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record RoomUpdateInfoResponse(
+        String title,
+        String description,
+        LocalDate endDate,
+        Integer participantLimit,
+        List<String> teamEmail
+) {
+}

--- a/src/main/java/com/oronaminc/join/room/dto/RoomUpdateRequest.java
+++ b/src/main/java/com/oronaminc/join/room/dto/RoomUpdateRequest.java
@@ -1,0 +1,39 @@
+package com.oronaminc.join.room.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.hibernate.validator.constraints.Length;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RoomUpdateRequest(
+        @NotBlank
+        @Length(min = 3, max = 20)
+        @Schema(description = "발표방 제목", example = "발표방1")
+        String title,
+
+        @NotBlank
+        @Length(max = 150)
+        @Schema(description = "발표방 간단한 설명", example = "오로나민C 발표방 입니다.")
+        String description,
+
+        @FutureOrPresent
+        @Schema(description = "발표방 종료 날짜", example = "2025-07-16")
+        LocalDate endDate,
+
+        @Max(50)
+        @Schema(description = "발표방 참여 제한 인원수", example = "16")
+        Integer participantLimit,
+
+        @NotNull
+        @Size(max = 5)
+        @Schema(description = "발표방 추가한 팀원 목록", example = "{팀원1@example.com, 팀원2@example.com}")
+        List<String> teamEmail
+) {
+}

--- a/src/main/java/com/oronaminc/join/room/dto/RoomUpdateStatusRequest.java
+++ b/src/main/java/com/oronaminc/join/room/dto/RoomUpdateStatusRequest.java
@@ -1,0 +1,8 @@
+package com.oronaminc.join.room.dto;
+
+import com.oronaminc.join.room.domain.RoomStatus;
+
+public record RoomUpdateStatusRequest(
+        RoomStatus roomStatus
+) {
+}

--- a/src/main/java/com/oronaminc/join/room/service/RoomService.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomService.java
@@ -9,8 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.oronaminc.join.document.domain.Document;
 import com.oronaminc.join.document.service.DocumentService;
-import com.oronaminc.join.emoji.service.EmojiService;
 import com.oronaminc.join.global.exception.ErrorException;
+import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.participant.domain.Participant;
 import com.oronaminc.join.participant.domain.ParticipantType;
 import com.oronaminc.join.participant.service.ParticipantService;
@@ -21,6 +21,7 @@ import com.oronaminc.join.room.dto.CreateRoomResponse;
 import com.oronaminc.join.room.dto.JoinRoomRequest;
 import com.oronaminc.join.room.dto.JoinRoomResponse;
 import com.oronaminc.join.room.dto.RoomDetailResponse;
+import com.oronaminc.join.room.dto.RoomUpdateRequest;
 import com.oronaminc.join.room.util.CodeGenerator;
 import com.oronaminc.join.room.util.RoomMapper;
 
@@ -32,7 +33,6 @@ import lombok.RequiredArgsConstructor;
 public class RoomService {
     private final RoomRepository roomRepository;
     private final ParticipantService participantService;
-    private final EmojiService emojiService;
     private final DocumentService documentService;
 
     private static final int CODE_LENGTH = 6;
@@ -64,6 +64,18 @@ public class RoomService {
         Document document = documentService.getDocumentByRoomId(roomId);
 
         return RoomMapper.toRoomDetailResponse(room, presenter, team, document, memberId);
+    }
+
+    public void updateRoom(Long memberId, Long roomId, RoomUpdateRequest updateRoomRequest) {
+        Member presenter = participantService.getPresenter(roomId).getMember();
+        if (!presenter.getId().equals(memberId)) {
+            throw new ErrorException(UNAUTHORIZED_UPDATE);
+        }
+
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
+        room.update(updateRoomRequest);
+        participantService.updateTeam(room, updateRoomRequest.teamEmail());
     }
 
     private String generateCode() {

--- a/src/main/java/com/oronaminc/join/room/service/RoomService.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomService.java
@@ -23,6 +23,7 @@ import com.oronaminc.join.room.dto.CreateRoomResponse;
 import com.oronaminc.join.room.dto.JoinRoomRequest;
 import com.oronaminc.join.room.dto.JoinRoomResponse;
 import com.oronaminc.join.room.dto.RoomDetailResponse;
+import com.oronaminc.join.room.dto.RoomUpdateInfoResponse;
 import com.oronaminc.join.room.dto.RoomUpdateRequest;
 import com.oronaminc.join.room.dto.RoomUpdateStatusRequest;
 import com.oronaminc.join.room.util.CodeGenerator;
@@ -107,6 +108,13 @@ public class RoomService {
             updateStatus = RoomStatus.ENDED;
         }
         room.updateStatus(updateStatus);
+    }
+
+    public RoomUpdateInfoResponse getRoomUpdateInfo(Long memberId, Long roomId) {
+        participantService.validatePresenter(roomId, memberId);
+        Room room = this.getRoomById(roomId);
+        List<Participant> team = participantService.getTeam(roomId);
+        return RoomMapper.toRoomUpdateInfoResponse(room, team);
     }
 
     private Room getRoomById(Long roomId) {

--- a/src/main/java/com/oronaminc/join/room/service/RoomService.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomService.java
@@ -105,7 +105,7 @@ public class RoomService {
         RoomStatus updateStatus = roomUpdateStatusRequest.roomStatus();
         List<RoomStatus> canUpdateStatus = List.of(RoomStatus.STARTED, RoomStatus.ENDED);
         if (!canUpdateStatus.contains(roomUpdateStatusRequest.roomStatus())) {
-            updateStatus = RoomStatus.ENDED;
+            throw new ErrorException(BAD_REQUEST_UPDATE_STATUS);
         }
         room.updateStatus(updateStatus);
     }

--- a/src/main/java/com/oronaminc/join/room/service/RoomService.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomService.java
@@ -11,7 +11,6 @@ import com.oronaminc.join.document.domain.Document;
 import com.oronaminc.join.document.service.DocumentService;
 import com.oronaminc.join.emoji.service.EmojiService;
 import com.oronaminc.join.global.exception.ErrorException;
-import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.participant.domain.Participant;
 import com.oronaminc.join.participant.domain.ParticipantType;
 import com.oronaminc.join.participant.service.ParticipantService;
@@ -25,6 +24,7 @@ import com.oronaminc.join.room.dto.JoinRoomRequest;
 import com.oronaminc.join.room.dto.JoinRoomResponse;
 import com.oronaminc.join.room.dto.RoomDetailResponse;
 import com.oronaminc.join.room.dto.RoomUpdateRequest;
+import com.oronaminc.join.room.dto.RoomUpdateStatusRequest;
 import com.oronaminc.join.room.util.CodeGenerator;
 import com.oronaminc.join.room.util.RoomMapper;
 
@@ -61,8 +61,7 @@ public class RoomService {
     public RoomDetailResponse getRoomDetail(Long memberId, Long roomId) {
         participantService.validateParticipant(memberId, roomId);
 
-        Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
+        Room room = this.getRoomById(roomId);
 
         Participant presenter = participantService.getPresenter(roomId);
         List<Participant> team = participantService.getTeam(roomId);
@@ -72,25 +71,20 @@ public class RoomService {
     }
 
     public void updateRoom(Long memberId, Long roomId, RoomUpdateRequest updateRoomRequest) {
-        Member presenter = participantService.getPresenter(roomId).getMember();
-        if (!presenter.getId().equals(memberId)) {
-            throw new ErrorException(UNAUTHORIZED_UPDATE_AND_DELETE);
-        }
-
-        Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
+        participantService.validatePresenter(roomId, memberId);
+        Room room = this.getRoomById(roomId);
 
         if (room.getRoomStatus().equals(RoomStatus.STARTED)) {
             throw new ErrorException(BAD_REQUEST_ROOM_STARTED);
         }
+
         room.update(updateRoomRequest);
         participantService.updateTeam(room, updateRoomRequest.teamEmail());
     }
 
     public void deleteRoom(Long memberId, Long roomId) {
         participantService.validatePresenter(roomId, memberId);
-        Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
+        Room room = this.getRoomById(roomId);
 
         if (room.getRoomStatus().equals(RoomStatus.STARTED)) {
             throw new ErrorException(BAD_REQUEST_ROOM_STARTED);
@@ -101,6 +95,23 @@ public class RoomService {
         emojiService.deleteByRoomEmoji(roomId);
         documentService.deleteByRoomId(roomId);
         roomRepository.deleteById(roomId);
+    }
+
+    public void updateRoomStatus(Long memberId, Long roomId, RoomUpdateStatusRequest roomUpdateStatusRequest) {
+        participantService.validatePresenter(roomId, memberId);
+        Room room = this.getRoomById(roomId);
+
+        RoomStatus updateStatus = roomUpdateStatusRequest.roomStatus();
+        List<RoomStatus> canUpdateStatus = List.of(RoomStatus.STARTED, RoomStatus.ENDED);
+        if (!canUpdateStatus.contains(roomUpdateStatusRequest.roomStatus())) {
+            updateStatus = RoomStatus.ENDED;
+        }
+        room.updateStatus(updateStatus);
+    }
+
+    private Room getRoomById(Long roomId) {
+        return roomRepository.findById(roomId)
+                .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
     }
 
     private String generateCode() {

--- a/src/main/java/com/oronaminc/join/room/service/RoomService.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomService.java
@@ -9,13 +9,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.oronaminc.join.document.domain.Document;
 import com.oronaminc.join.document.service.DocumentService;
+import com.oronaminc.join.emoji.service.EmojiService;
 import com.oronaminc.join.global.exception.ErrorException;
 import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.participant.domain.Participant;
 import com.oronaminc.join.participant.domain.ParticipantType;
 import com.oronaminc.join.participant.service.ParticipantService;
+import com.oronaminc.join.question.service.QuestionService;
 import com.oronaminc.join.room.dao.RoomRepository;
 import com.oronaminc.join.room.domain.Room;
+import com.oronaminc.join.room.domain.RoomStatus;
 import com.oronaminc.join.room.dto.CreateRoomRequest;
 import com.oronaminc.join.room.dto.CreateRoomResponse;
 import com.oronaminc.join.room.dto.JoinRoomRequest;
@@ -34,6 +37,8 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final ParticipantService participantService;
     private final DocumentService documentService;
+    private final QuestionService questionService;
+    private final EmojiService emojiService;
 
     private static final int CODE_LENGTH = 6;
 
@@ -69,13 +74,33 @@ public class RoomService {
     public void updateRoom(Long memberId, Long roomId, RoomUpdateRequest updateRoomRequest) {
         Member presenter = participantService.getPresenter(roomId).getMember();
         if (!presenter.getId().equals(memberId)) {
-            throw new ErrorException(UNAUTHORIZED_UPDATE);
+            throw new ErrorException(UNAUTHORIZED_UPDATE_AND_DELETE);
         }
 
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
+
+        if (room.getRoomStatus().equals(RoomStatus.STARTED)) {
+            throw new ErrorException(BAD_REQUEST_ROOM_STARTED);
+        }
         room.update(updateRoomRequest);
         participantService.updateTeam(room, updateRoomRequest.teamEmail());
+    }
+
+    public void deleteRoom(Long memberId, Long roomId) {
+        participantService.validatePresenter(roomId, memberId);
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
+
+        if (room.getRoomStatus().equals(RoomStatus.STARTED)) {
+            throw new ErrorException(BAD_REQUEST_ROOM_STARTED);
+        }
+
+        participantService.deleteParticipantByRoomId(roomId);
+        questionService.deleteByRoomId(roomId);
+        emojiService.deleteByRoomEmoji(roomId);
+        documentService.deleteByRoomId(roomId);
+        roomRepository.deleteById(roomId);
     }
 
     private String generateCode() {

--- a/src/main/java/com/oronaminc/join/room/util/RoomMapper.java
+++ b/src/main/java/com/oronaminc/join/room/util/RoomMapper.java
@@ -11,6 +11,7 @@ import com.oronaminc.join.room.domain.RoomType;
 import com.oronaminc.join.room.dto.CreateRoomRequest;
 import com.oronaminc.join.room.dto.CreateRoomResponse;
 import com.oronaminc.join.room.dto.RoomDetailResponse;
+import com.oronaminc.join.room.dto.RoomUpdateInfoResponse;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -53,6 +54,16 @@ public class RoomMapper {
                 )
                 .roomStatus(room.getRoomStatus())
                 .createdAt(room.getCreatedAt())
+                .build();
+    }
+
+    public static RoomUpdateInfoResponse toRoomUpdateInfoResponse(Room room, List<Participant> team) {
+        return RoomUpdateInfoResponse.builder()
+                .title(room.getTitle())
+                .description(room.getDescription())
+                .endDate(room.getEndedAt().toLocalDate())
+                .participantLimit(room.getParticipantLimit())
+                .teamEmail(team.stream().map(teamParticipant -> teamParticipant.getMember().getEmail()).toList())
                 .build();
     }
 }


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. (작업 파일)
room/service/RoomService

#### 2. (작업 내용 요약)

- 발표방 수정
![image](https://github.com/user-attachments/assets/d6acf545-84cf-4b61-b5f3-23f59cc0e51c)
수정이 없을 경우 기존 값을 그대로 입력 받아 수정하게 구현했습니다.
발표자가 아니거나 시작 상태이면 수정하지 못하게 했습니다. 

- 발표방 삭제
![image](https://github.com/user-attachments/assets/7eb8ba48-963e-4414-816a-6d1f1a31ba05)
각각 도메인에 해당하는 삭제 로직을 각 서비스에 구현해서 사용했습니다.

- 발표방 상태 변경
![image](https://github.com/user-attachments/assets/bc48b3fc-f453-428c-9064-a17fa36c747d)
STARTED나 ENDED 가 아닌 enum이 들어오면 예외 발생

- 발표방 수정용 조회
![image](https://github.com/user-attachments/assets/5fc0e3f5-a3cb-4bc8-9459-706650402716)
수정하지 않을 데이터를 위한 발표방 데이터 조회입니다.

<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

팀원을 수정하려면 팀원 정보가 필요했고, 팀원 정보를 조회해서 주는 김에 수정과 관련된 데이터를 API로 제공해 수정하는 데이터는 null 대신 기존 값을 입력 받게 구현했습니다. 

<br/>
