### PR TITLE
fix: 공감 버전 충돌 시 재시도 로직

### DIFF
--- a/src/main/java/com/oronaminc/join/emoji/service/EmojiFacade.java
+++ b/src/main/java/com/oronaminc/join/emoji/service/EmojiFacade.java
@@ -14,13 +14,16 @@ public class EmojiFacade {
 
     private final EmojiService emojiService;
 
-    public EmojiResponse toggleEmoji(Long memberId, EmojiRequest emojiRequest)
-        throws InterruptedException {
+    public EmojiResponse toggleEmoji(Long memberId, EmojiRequest emojiRequest) {
         for (int i = 0; i < 10; i++) {
             try {
                 return emojiService.toggleEmoji(memberId, emojiRequest);
             } catch (ObjectOptimisticLockingFailureException e) {
-                Thread.sleep(50);
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ex) {
+                    throw new ErrorException(ErrorCode.EMOJI_CONFLICT);
+                }
             }
         }
         throw new ErrorException(ErrorCode.EMOJI_CONFLICT);

--- a/src/main/java/com/oronaminc/join/emoji/service/EmojiFacade.java
+++ b/src/main/java/com/oronaminc/join/emoji/service/EmojiFacade.java
@@ -1,0 +1,29 @@
+package com.oronaminc.join.emoji.service;
+
+import com.oronaminc.join.emoji.dto.EmojiRequest;
+import com.oronaminc.join.emoji.dto.EmojiResponse;
+import com.oronaminc.join.global.exception.ErrorCode;
+import com.oronaminc.join.global.exception.ErrorException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmojiFacade {
+
+    private final EmojiService emojiService;
+
+    public EmojiResponse toggleEmoji(Long memberId, EmojiRequest emojiRequest)
+        throws InterruptedException {
+        for (int i = 0; i < 10; i++) {
+            try {
+                return emojiService.toggleEmoji(memberId, emojiRequest);
+            } catch (ObjectOptimisticLockingFailureException e) {
+                Thread.sleep(50);
+            }
+        }
+        throw new ErrorException(ErrorCode.EMOJI_CONFLICT);
+    }
+
+}

--- a/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.oronaminc.join.global.exception;
 
 import static com.oronaminc.join.global.exception.ErrorStatus.BAD_REQUEST;
+import static com.oronaminc.join.global.exception.ErrorStatus.CONFLICT;
 import static com.oronaminc.join.global.exception.ErrorStatus.FORBIDDEN;
 import static com.oronaminc.join.global.exception.ErrorStatus.INTERNAL_SERVER_ERROR;
 import static com.oronaminc.join.global.exception.ErrorStatus.NOT_FOUND;
@@ -42,7 +43,9 @@ public enum ErrorCode {
 
     SOCKET_ERROR("SOCKET-3000", "웹소켓 연결 중 서버 오류가 발생했습니다.", INTERNAL_SERVER_ERROR),
     SOCKET_RUNTIME_ERROR("SOCKET-2000", "처리되지 않은 오류가 발생했습니다", INTERNAL_SERVER_ERROR),
-    SOCKET_VALIDATION_ERROR("SOCKET-1001", "입력값이 유효하지 않습니다.", BAD_REQUEST);
+    SOCKET_VALIDATION_ERROR("SOCKET-1001", "입력값이 유효하지 않습니다.", BAD_REQUEST),
+
+    EMOJI_CONFLICT("EMOJI-001", "공감 처리 중 충돌이 발생했습니다.", CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/oronaminc/join/websocket/api/EmojiWebsocketController.java
+++ b/src/main/java/com/oronaminc/join/websocket/api/EmojiWebsocketController.java
@@ -2,22 +2,20 @@ package com.oronaminc.join.websocket.api;
 
 import com.oronaminc.join.emoji.dto.EmojiRequest;
 import com.oronaminc.join.emoji.dto.EmojiResponse;
-import com.oronaminc.join.emoji.service.EmojiService;
-import com.oronaminc.join.member.security.MemberDetails;
+import com.oronaminc.join.emoji.service.EmojiFacade;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 
 @Controller
 @RequiredArgsConstructor
 public class EmojiWebsocketController {
 
-    private final EmojiService emojiService;
+    private final EmojiFacade emojiFacade;
 
     @MessageMapping("/rooms/{roomId}/emojis")
     @SendTo("/topic/rooms/{roomId}/emojis")
@@ -28,7 +26,7 @@ public class EmojiWebsocketController {
     ) {
         Long memberId = Long.valueOf(principal.getName());
 
-        return emojiService.toggleEmoji(memberId, emojiRequest);
+        return emojiFacade.toggleEmoji(memberId, emojiRequest);
     }
 
 }

--- a/src/test/java/com/oronaminc/join/emoji/service/EmojiFacadeTests.java
+++ b/src/test/java/com/oronaminc/join/emoji/service/EmojiFacadeTests.java
@@ -1,0 +1,103 @@
+package com.oronaminc.join.emoji.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.oronaminc.join.answer.service.AnswerReader;
+import com.oronaminc.join.emoji.domain.TargetType;
+import com.oronaminc.join.emoji.dto.EmojiRequest;
+import com.oronaminc.join.member.dao.MemberRepository;
+import com.oronaminc.join.member.domain.Member;
+import com.oronaminc.join.member.service.MemberReader;
+import com.oronaminc.join.question.service.QuestionReader;
+import com.oronaminc.join.room.dao.RoomRepository;
+import com.oronaminc.join.room.domain.Room;
+import com.oronaminc.join.room.domain.RoomStatus;
+import com.oronaminc.join.room.service.RoomReader;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@Import({EmojiFacade.class, EmojiService.class, MemberReader.class, EmojiReader.class,
+    RoomReader.class, QuestionReader.class, AnswerReader.class})
+@ActiveProfiles("test")
+class EmojiFacadeTests {
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EmojiFacade emojiFacade;
+
+
+    @Test
+    @DisplayName("동시에 50개의 공감 요청")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void toggleEmoji_success_test() throws InterruptedException {
+
+        // given
+        Room savedRoom = roomRepository.saveAndFlush(
+            Room.builder()
+                .title("제목")
+                .description("내용")
+                .secretCode("123456")
+                .emojiCount(0L)
+                .participantLimit(0)
+                .endedAt(LocalDateTime.now())
+                .version(0)
+                .roomStatus(RoomStatus.STARTED)
+                .build()
+        );
+        Long roomId = savedRoom.getId();
+
+        int threadCount = 50;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        List<Member> members = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            Member member = Member.builder().build();
+            members.add(memberRepository.saveAndFlush(member));
+            System.out.println("memberId: " + members.get(i).getId());
+        }
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executorService.submit(() -> {
+                try {
+                    emojiFacade.toggleEmoji(members.get(idx).getId(),
+                        new EmojiRequest(TargetType.ROOM, roomId));
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        Room findRoom = roomRepository.findById(roomId).orElse(null);
+        assertThat(findRoom.getEmojiCount()).isEqualTo(50);
+        assertThat(findRoom.getVersion()).isEqualTo(50);
+
+    }
+
+}


### PR DESCRIPTION
## ✨ 설명
close #47 
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. (작업 파일)
websocket/api/EmojiWebsocketController
emoji/service/EmojiFacade
global/exception/ErrorCode
emoji/service/EmojiFacadeTests

#### 2. (작업 내용 요약)
- 낙관적 락 충돌 시 최대 10회 재시도합니다. (실패 시 예외 발생)
- 50명이 동시에 동일 발표방에 공감을 생성하는 테스트를 통과하긴 했지만, 실제 배포 후 테스트해보면서 재조정해야 할 것 같습니다.
```java
public EmojiResponse toggleEmoji(Long memberId, EmojiRequest emojiRequest) {
        for (int i = 0; i < 10; i++) {
            try {
                return emojiService.toggleEmoji(memberId, emojiRequest);
            } catch (ObjectOptimisticLockingFailureException e) {
                try {
                    Thread.sleep(50);
                } catch (InterruptedException ex) {
                    throw new ErrorException(ErrorCode.EMOJI_CONFLICT);
                }
            }
        }
        throw new ErrorException(ErrorCode.EMOJI_CONFLICT);
    }
```

<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- (리뷰 받고 싶거나 알리고 싶은 내용)

<br/>
