### PR TITLE
refactor: 질문 정렬에 queryDsl 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,12 @@ dependencies {
 
     // S3
     implementation 'software.amazon.awssdk:s3:2.31.77'
+
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/oronaminc/join/global/config/QueryDslConfig.java
+++ b/src/main/java/com/oronaminc/join/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.oronaminc.join.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepository.java
+++ b/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepository.java
@@ -1,0 +1,13 @@
+package com.oronaminc.join.question.dao;
+
+import com.oronaminc.join.question.domain.QuestionSort;
+import com.oronaminc.join.question.dto.QuestionFlatResponse;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
+
+public interface QuestionCustomRepository {
+
+    List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiId,
+        Long lastEmojiCount, Long memberId, Long roomId, QuestionSort sortType, Pageable pageable);
+}

--- a/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepository.java
+++ b/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface QuestionCustomRepository {
 
-    List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiId,
-        Long lastEmojiCount, Long memberId, Long roomId, QuestionSort sortType, Pageable pageable);
+    List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiCount,
+        Long memberId, Long roomId, QuestionSort sortType, Pageable pageable);
 }

--- a/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepository.java
+++ b/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepository.java
@@ -4,7 +4,6 @@ import com.oronaminc.join.question.domain.QuestionSort;
 import com.oronaminc.join.question.dto.QuestionFlatResponse;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
 
 public interface QuestionCustomRepository {
 

--- a/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepositoryImpl.java
+++ b/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepositoryImpl.java
@@ -1,0 +1,109 @@
+package com.oronaminc.join.question.dao;
+
+import static com.oronaminc.join.answer.domain.QAnswer.answer;
+import static com.oronaminc.join.emoji.domain.QEmoji.emoji;
+import static com.oronaminc.join.member.domain.QMember.member;
+import static com.oronaminc.join.question.domain.QQuestion.question;
+
+import com.oronaminc.join.answer.domain.QAnswer;
+import com.oronaminc.join.emoji.domain.QEmoji;
+import com.oronaminc.join.member.domain.QMember;
+import com.oronaminc.join.question.domain.QQuestion;
+import com.oronaminc.join.question.domain.QuestionSort;
+import com.oronaminc.join.question.dto.QuestionFlatResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@AllArgsConstructor
+public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiId,
+        Long lastEmojiCount, Long memberId, Long roomId, QuestionSort sortType, Pageable pageable) {
+
+        Predicate where = createPredicate(lastId, lastEmojiId, lastEmojiCount, memberId, roomId,
+            sortType);
+
+        JPAQuery<QuestionFlatResponse> query = jpaQueryFactory
+            .select(Projections.constructor(QuestionFlatResponse.class,
+                question.id,
+                question.content,
+                question.emojiCount,
+                JPAExpressions.selectOne().from(answer).where(answer.question.eq(question))
+                    .exists(),
+                JPAExpressions.selectOne().from(emoji).where(emoji.member.id.eq(memberId)).exists(),
+                member.id,
+                member.nickname,
+                question.createdAt
+            ))
+            .from(question)
+            .join(question.member, member)
+            .where(where)
+            .orderBy(createOrderSpecifiers(sortType));
+
+        return query
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+
+    private Predicate createPredicate(Long lastId, Long lastEmojiId,
+        Long lastEmojiCount, Long memberId, Long roomId, QuestionSort sortType) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(question.room.id.eq(roomId));
+
+        switch (sortType) {
+            case CREATEDAT -> {
+                if (lastId != null) {
+                    builder.and(question.id.lt(lastId));
+                }
+            }
+            case EMOJI -> {
+                if (lastEmojiId != null) {
+                    builder.and(
+                        question.emojiCount.lt(lastEmojiCount)
+                            .or(question.emojiCount.eq(lastEmojiCount).and(question.id.lt(lastId)))
+                    );
+                }
+            }
+            case MYQUESTION -> {
+                builder.and(question.member.id.eq(memberId));
+                if (lastId != null) {
+                    builder.and(question.id.lt(lastId));
+                }
+            }
+        }
+
+        return builder;
+    }
+
+    private OrderSpecifier<?>[] createOrderSpecifiers(QuestionSort sortType) {
+
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        // 공감순인 경우에만 emojiCount 정렬 조건 추가
+        if (sortType.equals(QuestionSort.EMOJI)) {
+            orders.add(new OrderSpecifier<>(Order.DESC, question.emojiCount));
+        }
+
+        // 최신순, 내 질문
+        orders.add(new OrderSpecifier<>(Order.DESC, question.id));
+
+        return orders.toArray(new OrderSpecifier[0]);
+    }
+}

--- a/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepositoryImpl.java
+++ b/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepositoryImpl.java
@@ -5,10 +5,6 @@ import static com.oronaminc.join.emoji.domain.QEmoji.emoji;
 import static com.oronaminc.join.member.domain.QMember.member;
 import static com.oronaminc.join.question.domain.QQuestion.question;
 
-import com.oronaminc.join.answer.domain.QAnswer;
-import com.oronaminc.join.emoji.domain.QEmoji;
-import com.oronaminc.join.member.domain.QMember;
-import com.oronaminc.join.question.domain.QQuestion;
 import com.oronaminc.join.question.domain.QuestionSort;
 import com.oronaminc.join.question.dto.QuestionFlatResponse;
 import com.querydsl.core.BooleanBuilder;
@@ -21,10 +17,10 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;

--- a/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepositoryImpl.java
+++ b/src/main/java/com/oronaminc/join/question/dao/QuestionCustomRepositoryImpl.java
@@ -23,19 +23,17 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
-@Repository
 @AllArgsConstructor
 public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiId,
-        Long lastEmojiCount, Long memberId, Long roomId, QuestionSort sortType, Pageable pageable) {
+    public List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiCount,
+        Long memberId, Long roomId, QuestionSort sortType, Pageable pageable) {
 
-        Predicate where = createPredicate(lastId, lastEmojiId, lastEmojiCount, memberId, roomId,
+        Predicate where = createPredicate(lastId, lastEmojiCount, memberId, roomId,
             sortType);
 
         JPAQuery<QuestionFlatResponse> query = jpaQueryFactory
@@ -61,8 +59,8 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
             .fetch();
     }
 
-    private Predicate createPredicate(Long lastId, Long lastEmojiId,
-        Long lastEmojiCount, Long memberId, Long roomId, QuestionSort sortType) {
+    private Predicate createPredicate(Long lastId, Long lastEmojiCount,
+        Long memberId, Long roomId, QuestionSort sortType) {
 
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(question.room.id.eq(roomId));
@@ -74,7 +72,7 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
                 }
             }
             case EMOJI -> {
-                if (lastEmojiId != null) {
+                if (lastEmojiCount != null) {
                     builder.and(
                         question.emojiCount.lt(lastEmojiCount)
                             .or(question.emojiCount.eq(lastEmojiCount).and(question.id.lt(lastId)))

--- a/src/main/java/com/oronaminc/join/question/dao/QuestionRepository.java
+++ b/src/main/java/com/oronaminc/join/question/dao/QuestionRepository.java
@@ -11,97 +11,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface QuestionRepository extends JpaRepository<Question, Long> {
+public interface QuestionRepository extends JpaRepository<Question, Long>, QuestionCustomRepository {
 
     Optional<Question> findByIdAndRoomId(Long questionId, Long roomId);
-
-    @Query("""
-        SELECT new com.oronaminc.join.question.dto.QuestionFlatResponse(
-            q.id,
-            q.content,
-            q.emojiCount,
-            (CASE WHEN EXISTS (
-                SELECT a FROM Answer a 
-                WHERE a.question = q
-            ) THEN true ELSE false END),
-            (CASE WHEN EXISTS (
-                SELECT e FROM Emoji e 
-                WHERE e.member.id = :memberId 
-                AND e.targetType = com.oronaminc.join.emoji.domain.TargetType.QUESTION
-                AND e.targetId = q.id
-            ) THEN true ELSE false END),
-             m.id,
-             m.nickname,
-             q.createdAt
-        )
-        FROM Question q
-        JOIN q.member m
-        WHERE :roomId = q.room.id
-        AND (:lastId IS NULL OR q.id < :lastId)
-        ORDER BY q.id DESC 
-    """)
-    List<QuestionFlatResponse> findByCreatedAt(@Param("lastId") Long lastId,
-        @Param("memberId") Long memberId, @Param("roomId") Long roomId, Pageable pageable);
-
-    @Query("""
-        SELECT new com.oronaminc.join.question.dto.QuestionFlatResponse(
-            q.id,
-            q.content,
-            q.emojiCount,
-            (CASE WHEN EXISTS (
-                SELECT a FROM Answer a  
-                WHERE a.question = q
-            ) THEN true ELSE false END),
-            (CASE WHEN EXISTS (
-                SELECT e FROM Emoji e 
-                WHERE e.member.id = :memberId 
-                AND e.targetType = com.oronaminc.join.emoji.domain.TargetType.QUESTION
-                AND e.targetId = q.id
-            ) THEN true ELSE false END),
-             m.id,
-             m.nickname,
-             q.createdAt
-        )
-        FROM Question q
-        JOIN q.member m
-        WHERE :roomId = q.room.id
-        AND (:lastEmojiCount IS NULL OR (
-            q.emojiCount < :lastEmojiCount OR (q.emojiCount = :lastEmojiCount AND q.id < :lastId)
-        ))
-        ORDER BY q.emojiCount DESC, q.id DESC 
-    """)
-    List<QuestionFlatResponse> findByEmojiCount(@Param("lastId") Long lastId,
-        @Param("lastEmojiCount") Long lastEmojiCount,
-        @Param("memberId") Long memberId, @Param("roomId") Long roomId, Pageable pageable);
-
-    @Query("""
-        SELECT new com.oronaminc.join.question.dto.QuestionFlatResponse(
-            q.id,
-            q.content,
-            q.emojiCount,
-            (CASE WHEN EXISTS (
-                SELECT a FROM Answer a 
-                WHERE a.question = q
-            ) THEN true ELSE false END),
-            (CASE WHEN EXISTS (
-                SELECT e FROM Emoji e 
-                WHERE e.member.id = :memberId 
-                AND e.targetType = com.oronaminc.join.emoji.domain.TargetType.QUESTION
-                AND e.targetId = q.id
-            ) THEN true ELSE false END),
-             m.id,
-             m.nickname,
-             q.createdAt
-        )
-        FROM Question q
-        JOIN q.member m
-        WHERE :roomId = q.room.id
-        AND  q.member.id = :memberId
-        AND (:lastId IS NULL OR  q.id > :lastId)
-        ORDER BY q.id DESC 
-    """)
-    List<QuestionFlatResponse> findByMyQuestion(@Param("lastId") Long lastId,
-        @Param("memberId") Long memberId, @Param("roomId") Long roomId, Pageable pageable);
 
     @Query("""
         select q.room.id, count(q)

--- a/src/main/java/com/oronaminc/join/question/dao/QuestionRepository.java
+++ b/src/main/java/com/oronaminc/join/question/dao/QuestionRepository.java
@@ -2,7 +2,6 @@ package com.oronaminc.join.question.dao;
 
 import com.oronaminc.join.question.domain.Question;
 import java.util.Optional;
-import com.oronaminc.join.question.dto.QuestionFlatResponse;
 import java.util.List;
 
 import com.oronaminc.join.room.dto.TopQnADto;

--- a/src/main/java/com/oronaminc/join/question/service/QuestionReader.java
+++ b/src/main/java/com/oronaminc/join/question/service/QuestionReader.java
@@ -1,28 +1,24 @@
 package com.oronaminc.join.question.service;
 
-import com.oronaminc.join.question.dao.QuestionCustomRepository;
-import com.oronaminc.join.question.domain.QuestionSort;
-import java.util.List;
-import java.util.Optional;
-
-import com.oronaminc.join.room.dto.TopQnADto;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Component;
-
 import com.oronaminc.join.global.exception.ErrorCode;
 import com.oronaminc.join.global.exception.ErrorException;
 import com.oronaminc.join.question.dao.QuestionRepository;
 import com.oronaminc.join.question.domain.Question;
+import com.oronaminc.join.question.domain.QuestionSort;
 import com.oronaminc.join.question.dto.QuestionFlatResponse;
-
+import com.oronaminc.join.room.dto.TopQnADto;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class QuestionReader {
+
     private final QuestionRepository questionRepository;
-    private final QuestionCustomRepository questionCustomRepository;
 
     public Optional<Question> findById(Long questionId) {
         return questionRepository.findById(questionId);
@@ -30,7 +26,7 @@ public class QuestionReader {
 
     public Question getById(Long questionId) {
         return this.findById(questionId)
-                .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_QUESTION));
+            .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_QUESTION));
     }
 
     public Optional<Question> findByIdAndRoomId(Long questionId, Long roomId) {
@@ -39,12 +35,13 @@ public class QuestionReader {
 
     public Question getByIdAndRoomId(Long questionId, Long roomId) {
         return this.findByIdAndRoomId(questionId, roomId)
-                .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_ROOM_QUESTION));
+            .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_ROOM_QUESTION));
     }
+
     public List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiCount,
         Long memberId, Long roomId, QuestionSort sortType, Pageable pageable) {
-        return questionCustomRepository.findQuestionsOrderBy(lastId, lastEmojiCount,
-             memberId, roomId, sortType, pageable);
+        return questionRepository.findQuestionsOrderBy(lastId, lastEmojiCount,
+            memberId, roomId, sortType, pageable);
     }
 
     public List<Question> findByRoomId(Long roomId) {
@@ -59,9 +56,11 @@ public class QuestionReader {
         return !questionRepository.findByRoomId(roomId).isEmpty();
     }
 
-    public Long countByRoomId(Long roomId) { return questionRepository.countByRoomId(roomId);}
+    public Long countByRoomId(Long roomId) {
+        return questionRepository.countByRoomId(roomId);
+    }
 
     public List<TopQnADto> findTop3QnA(Long roomId) {
-        return questionRepository.findTop3QnAByRoomId(roomId, PageRequest.of(0,3));
+        return questionRepository.findTop3QnAByRoomId(roomId, PageRequest.of(0, 3));
     }
 }

--- a/src/main/java/com/oronaminc/join/question/service/QuestionReader.java
+++ b/src/main/java/com/oronaminc/join/question/service/QuestionReader.java
@@ -1,5 +1,6 @@
 package com.oronaminc.join.question.service;
 
+import com.oronaminc.join.question.dao.QuestionCustomRepository;
 import com.oronaminc.join.question.domain.QuestionSort;
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class QuestionReader {
     private final QuestionRepository questionRepository;
+    private final QuestionCustomRepository questionCustomRepository;
 
     public Optional<Question> findById(Long questionId) {
         return questionRepository.findById(questionId);
@@ -39,10 +41,10 @@ public class QuestionReader {
         return this.findByIdAndRoomId(questionId, roomId)
                 .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_ROOM_QUESTION));
     }
-    public List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiId,
-        Long lastEmojiCount, Long memberId, Long roomId, QuestionSort sortType, Pageable pageable) {
-        return questionRepository.findQuestionsOrderBy(lastId, lastEmojiId,
-            lastEmojiCount, memberId, roomId, sortType, pageable);
+    public List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiCount,
+        Long memberId, Long roomId, QuestionSort sortType, Pageable pageable) {
+        return questionCustomRepository.findQuestionsOrderBy(lastId, lastEmojiCount,
+             memberId, roomId, sortType, pageable);
     }
 
     public List<Question> findByRoomId(Long roomId) {

--- a/src/main/java/com/oronaminc/join/question/service/QuestionReader.java
+++ b/src/main/java/com/oronaminc/join/question/service/QuestionReader.java
@@ -1,5 +1,6 @@
 package com.oronaminc.join.question.service;
 
+import com.oronaminc.join.question.domain.QuestionSort;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,17 +39,10 @@ public class QuestionReader {
         return this.findByIdAndRoomId(questionId, roomId)
                 .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_ROOM_QUESTION));
     }
-
-    public List<QuestionFlatResponse> findByCreatedAt(Long lastId, Long memberId, Long roomId, Pageable pageable) {
-        return questionRepository.findByCreatedAt(lastId, memberId, roomId, pageable);
-    }
-
-    public List<QuestionFlatResponse> findByEmojiCount(Long lastId, Long lastEmojiCount, Long memberId, Long roomId, Pageable pageable) {
-        return questionRepository.findByEmojiCount(lastId, lastEmojiCount, memberId, roomId, pageable);
-    }
-
-    public List<QuestionFlatResponse> findByMyQuestion(Long lastId, Long memberId, Long roomId, Pageable pageable) {
-        return questionRepository.findByMyQuestion(lastId, memberId, roomId, pageable);
+    public List<QuestionFlatResponse> findQuestionsOrderBy(Long lastId, Long lastEmojiId,
+        Long lastEmojiCount, Long memberId, Long roomId, QuestionSort sortType, Pageable pageable) {
+        return questionRepository.findQuestionsOrderBy(lastId, lastEmojiId,
+            lastEmojiCount, memberId, roomId, sortType, pageable);
     }
 
     public List<Question> findByRoomId(Long roomId) {

--- a/src/main/java/com/oronaminc/join/question/service/QuestionService.java
+++ b/src/main/java/com/oronaminc/join/question/service/QuestionService.java
@@ -1,20 +1,12 @@
 package com.oronaminc.join.question.service;
 
+import com.oronaminc.join.answer.service.AnswerService;
 import com.oronaminc.join.global.exception.ErrorCode;
 import com.oronaminc.join.global.exception.ErrorException;
-import com.oronaminc.join.participant.service.ParticipantReader;
-import java.util.List;
-
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.oronaminc.join.answer.service.AnswerService;
 import com.oronaminc.join.global.util.SliceUtil;
 import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.member.service.MemberReader;
+import com.oronaminc.join.participant.service.ParticipantReader;
 import com.oronaminc.join.participant.service.ParticipantService;
 import com.oronaminc.join.question.dao.QuestionRepository;
 import com.oronaminc.join.question.domain.Question;
@@ -25,8 +17,13 @@ import com.oronaminc.join.question.dto.QuestionFlatResponse;
 import com.oronaminc.join.question.util.QuestionMapper;
 import com.oronaminc.join.room.domain.Room;
 import com.oronaminc.join.room.service.RoomReader;
-
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -81,7 +78,8 @@ public class QuestionService {
     }
 
     @Transactional
-    public Question update(Long memberId, Long roomId, Long questionId, QuestionCreateRequest request) {
+    public Question update(Long memberId, Long roomId, Long questionId,
+        QuestionCreateRequest request) {
         Question question = questionReader.getByIdAndRoomId(questionId, roomId);
 
         // 참여자가 아님
@@ -110,7 +108,7 @@ public class QuestionService {
 
         // 관리자가 아님 && 작성자도 아님
         if (!participantReader.existsPresenterOrTeamByMemberId(roomId, memberId)
-        && !question.getMember().getId().equals(memberId)) {
+            && !question.getMember().getId().equals(memberId)) {
             throw new ErrorException(ErrorCode.UNAUTHORIZED_DELETE_QUESTION);
         }
 

--- a/src/main/java/com/oronaminc/join/question/service/QuestionService.java
+++ b/src/main/java/com/oronaminc/join/question/service/QuestionService.java
@@ -70,14 +70,9 @@ public class QuestionService {
 
         Pageable pageable = PageRequest.of(0, size + 1);
 
-        List<QuestionFlatResponse> questions = switch (sort) {
-            case QuestionSort.CREATEDAT -> questionReader.findByCreatedAt(lastId,
-                memberId, roomId, pageable);
-            case QuestionSort.EMOJI -> questionReader.findByEmojiCount(lastId,
-                lastEmojiCount, memberId, roomId, pageable);
-            case QuestionSort.MYQUESTION -> questionReader.findByMyQuestion(lastId,
-                memberId, roomId, pageable);
-        };
+        List<QuestionFlatResponse> questions = questionReader.findQuestionsOrderBy(lastId,
+            lastEmojiCount, memberId, roomId, sort,
+            pageable);
 
         List<QuestionAssembleResponse> assembledList = questions.stream()
             .map(QuestionMapper::toQuestionListResponse).toList();

--- a/src/test/java/com/oronaminc/join/config/TestQueryDslConfig.java
+++ b/src/test/java/com/oronaminc/join/config/TestQueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.oronaminc.join.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/oronaminc/join/emoji/service/EmojiFacadeTests.java
+++ b/src/test/java/com/oronaminc/join/emoji/service/EmojiFacadeTests.java
@@ -3,6 +3,7 @@ package com.oronaminc.join.emoji.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.oronaminc.join.answer.service.AnswerReader;
+import com.oronaminc.join.config.TestQueryDslConfig;
 import com.oronaminc.join.emoji.dao.EmojiRepository;
 import com.oronaminc.join.emoji.domain.Emoji;
 import com.oronaminc.join.emoji.domain.TargetType;
@@ -32,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 @Import({EmojiFacade.class, EmojiService.class, MemberReader.class, EmojiReader.class,
-    RoomReader.class, QuestionReader.class, AnswerReader.class})
+    RoomReader.class, QuestionReader.class, AnswerReader.class, TestQueryDslConfig.class})
 @ActiveProfiles("test")
 class EmojiFacadeTests {
 

--- a/src/test/java/com/oronaminc/join/participant/dao/ParticipantRepositoryTests.java
+++ b/src/test/java/com/oronaminc/join/participant/dao/ParticipantRepositoryTests.java
@@ -2,6 +2,7 @@ package com.oronaminc.join.participant.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.oronaminc.join.config.TestQueryDslConfig;
 import com.oronaminc.join.member.dao.MemberRepository;
 import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.member.dto.ParticipantCountDto;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Import(TestQueryDslConfig.class)
 class ParticipantRepositoryTests {
 
     @Autowired

--- a/src/test/java/com/oronaminc/join/question/dao/QuestionRepositoryTests.java
+++ b/src/test/java/com/oronaminc/join/question/dao/QuestionRepositoryTests.java
@@ -2,6 +2,8 @@ package com.oronaminc.join.question.dao;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import com.oronaminc.join.config.TestQueryDslConfig;
+import com.oronaminc.join.question.domain.QuestionSort;
 import com.oronaminc.join.question.dto.QuestionFlatResponse;
 import java.util.Comparator;
 import java.util.List;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
@@ -16,6 +19,7 @@ import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Import(TestQueryDslConfig.class)
 @Sql(scripts = "/question-test-data.sql")
 class QuestionRepositoryTests {
 
@@ -31,9 +35,8 @@ class QuestionRepositoryTests {
         Long roomId = 1L;
 
         // when
-        List<QuestionFlatResponse> result = questionRepository.findByCreatedAt(
-            null, memberId, roomId, pageable
-        );
+        List<QuestionFlatResponse> result = questionRepository.findQuestionsOrderBy(
+            null, null, memberId, roomId, QuestionSort.CREATEDAT, pageable);
 
         // then
         assertThat(result).hasSize(5);
@@ -50,9 +53,8 @@ class QuestionRepositoryTests {
         Long roomId = 1L;
 
         // when
-        List<QuestionFlatResponse> result = questionRepository.findByEmojiCount(
-            null, null, memberId, roomId, pageable
-        );
+        List<QuestionFlatResponse> result = questionRepository.findQuestionsOrderBy(
+            null, null, memberId, roomId, QuestionSort.EMOJI, pageable);
 
         // then
         assertThat(result).hasSize(5);
@@ -70,9 +72,8 @@ class QuestionRepositoryTests {
         Long roomId = 1L;
 
         // when
-        List<QuestionFlatResponse> result = questionRepository.findByMyQuestion(
-            null, memberId, roomId, pageable
-        );
+        List<QuestionFlatResponse> result = questionRepository.findQuestionsOrderBy(
+            null, null, memberId, roomId, QuestionSort.MYQUESTION, pageable);
 
         // then
         assertThat(result).hasSize(5);

--- a/src/test/java/com/oronaminc/join/question/service/QuestionServiceTests.java
+++ b/src/test/java/com/oronaminc/join/question/service/QuestionServiceTests.java
@@ -37,6 +37,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -204,12 +205,13 @@ class QuestionServiceTests {
         Long roomId = 1L;
         Long memberId = 1L;
         int size = 1;
+        Pageable pageable = PageRequest.of(0, size + 1);
 
         List<QuestionFlatResponse> mockList = List.of(mockQ1, mockQ2);
 
         given(memberReader.getById(memberId)).willReturn(mockMember);
         given(roomReader.getById(roomId)).willReturn(mockRoom);
-        given(questionReader.findByCreatedAt(null, memberId, roomId, PageRequest.of(0, size + 1)))
+        given(questionReader.findQuestionsOrderBy(null, null, memberId, roomId, QuestionSort.CREATEDAT, pageable))
             .willReturn(mockList);
 
         Slice<QuestionAssembleResponse> result = questionService.getQuestions(
@@ -227,13 +229,13 @@ class QuestionServiceTests {
         Long roomId = 1L;
         Long memberId = 1L;
         int size = 1;
+        Pageable pageable = PageRequest.of(0, size + 1);
 
         List<QuestionFlatResponse> mockList = List.of(mockQ1, mockQ2);
 
         given(memberReader.getById(memberId)).willReturn(mockMember);
         given(roomReader.getById(roomId)).willReturn(mockRoom);
-        given(questionReader.findByEmojiCount(null, null, memberId, roomId,
-            PageRequest.of(0, size + 1)))
+        given(questionReader.findQuestionsOrderBy(null, null, memberId, roomId, QuestionSort.EMOJI, pageable))
             .willReturn(mockList);
 
         Slice<QuestionAssembleResponse> result = questionService.getQuestions(QuestionSort.EMOJI,
@@ -250,12 +252,13 @@ class QuestionServiceTests {
         Long roomId = 1L;
         Long memberId = 1L;
         int size = 1;
+        Pageable pageable = PageRequest.of(0, size + 1);
 
         List<QuestionFlatResponse> mockList = List.of(mockQ1, mockQ2);
 
         given(memberReader.getById(memberId)).willReturn(mockMember);
         given(roomReader.getById(roomId)).willReturn(mockRoom);
-        given(questionReader.findByMyQuestion(null, memberId, roomId, PageRequest.of(0, size + 1)))
+        given(questionReader.findQuestionsOrderBy(null, null, memberId, roomId, QuestionSort.MYQUESTION, pageable))
             .willReturn(mockList);
 
         Slice<QuestionAssembleResponse> result = questionService.getQuestions(


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#53 

#### 1. (작업 파일)

- build.gradle
- question 

#### 2. (작업 내용 요약)

기존 질문 정렬하는 쿼리가 where절과 orderBy절만 살짝 다르고 동일했어서, querydsl로 리팩토링 진행하였습니다.

`QuestionCustomRepositoryImpl`에서 정렬 조건에 따라 동적으로 쿼리를 생성합니다.

<img width="890" height="280" alt="image" src="https://github.com/user-attachments/assets/5b609459-a56f-4e16-8208-5089bc46445e" />

분기로 정렬 메소드를 다르게 호출하지 않아도 하나로 처리 가능해졌습니다!


<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- 블로그들을 보니 리포지토리 이름에 Custom을 붙여서 사용해서 저도 동일하게 했습니다. 혹시 다른 이름이 나을 것 같다면 말씀해주세요!
- `TestQueryDslConfig`는 repository 슬라이스 테스트 할 때 JpaQueryFactor가 빈으로 등록되지 않는 문제를 해결하기 위해 추가했습니다.

- 이후 @DataJpaTest를 진행하실 때 쿼리dsl을 사용하지 않아도, `@Import(TestQueryDslConfig.class)`를 추가하지 않으시면 테스트가 실패하실 겁니다.. 확인 부탁드립니닷

<br/>
