### PR TITLE
refactor: 파일 업로드 로직 수정

### DIFF
--- a/src/main/java/com/oronaminc/join/document/event/DocumentCreateEvent.java
+++ b/src/main/java/com/oronaminc/join/document/event/DocumentCreateEvent.java
@@ -1,0 +1,3 @@
+package com.oronaminc.join.document.event;
+
+public record DocumentCreateEvent(String objectKey, String fileName) { }

--- a/src/main/java/com/oronaminc/join/document/event/DocumentEventHandler.java
+++ b/src/main/java/com/oronaminc/join/document/event/DocumentEventHandler.java
@@ -25,11 +25,9 @@ public class DocumentEventHandler {
         try {
             s3Service.moveObject(event.objectKey(), newKey);
 
-            log.info("✅ S3 파일 이동 성공: {} → {}", event.objectKey(), newKey);
+            log.debug("✅ S3 파일 이동 성공: {} → {}", event.objectKey(), newKey);
         } catch (Exception e) {
-            log.info("원본 키: {}", event.objectKey());
-            log.info("디코딩 키: {}", URLDecoder.decode(event.objectKey(), StandardCharsets.UTF_8));
-            log.info("❌ S3 파일 이동 실패: {} → {}, 이유: {}", event.objectKey(), newKey, e.getMessage(), e);
+            log.debug("❌ S3 파일 이동 실패: {} → {}, 이유: {}", event.objectKey(), newKey, e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/oronaminc/join/document/event/DocumentEventHandler.java
+++ b/src/main/java/com/oronaminc/join/document/event/DocumentEventHandler.java
@@ -1,6 +1,8 @@
 package com.oronaminc.join.document.event;
 
 
+import com.oronaminc.join.global.exception.ErrorCode;
+import com.oronaminc.join.global.exception.ErrorException;
 import com.oronaminc.join.infra.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,8 +10,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Component
@@ -27,7 +27,8 @@ public class DocumentEventHandler {
 
             log.debug("✅ S3 파일 이동 성공: {} → {}", event.objectKey(), newKey);
         } catch (Exception e) {
-            log.debug("❌ S3 파일 이동 실패: {} → {}, 이유: {}", event.objectKey(), newKey, e.getMessage(), e);
+            log.error("❌ S3 파일 이동 실패: {} → {}, 이유: {}", event.objectKey(), newKey, e.getMessage(), e);
+            throw new ErrorException(ErrorCode.MOVEMENT_FILE_FAILED);
         }
     }
 }

--- a/src/main/java/com/oronaminc/join/document/event/DocumentEventHandler.java
+++ b/src/main/java/com/oronaminc/join/document/event/DocumentEventHandler.java
@@ -1,0 +1,35 @@
+package com.oronaminc.join.document.event;
+
+
+import com.oronaminc.join.infra.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DocumentEventHandler {
+
+    private final S3Service s3Service;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDocumentEvent(DocumentCreateEvent event) {
+        String newKey = "documents/" + event.fileName();
+
+        try {
+            s3Service.moveObject(event.objectKey(), newKey);
+
+            log.info("✅ S3 파일 이동 성공: {} → {}", event.objectKey(), newKey);
+        } catch (Exception e) {
+            log.info("원본 키: {}", event.objectKey());
+            log.info("디코딩 키: {}", URLDecoder.decode(event.objectKey(), StandardCharsets.UTF_8));
+            log.info("❌ S3 파일 이동 실패: {} → {}, 이유: {}", event.objectKey(), newKey, e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/oronaminc/join/document/service/DocumentService.java
+++ b/src/main/java/com/oronaminc/join/document/service/DocumentService.java
@@ -1,5 +1,7 @@
 package com.oronaminc.join.document.service;
 
+import com.oronaminc.join.document.event.DocumentCreateEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import com.oronaminc.join.document.dao.DocumentRepository;
@@ -15,6 +17,8 @@ import jakarta.transaction.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 
@@ -24,6 +28,7 @@ public class DocumentService {
 
     private final DocumentRepository documentRepository;
     private final S3Service s3Service;
+    private final ApplicationEventPublisher publisher;
 
     public void deleteByRoomId(Long roomId) {
         documentRepository.deleteByRoomId(roomId);
@@ -34,8 +39,16 @@ public class DocumentService {
             throw new ErrorException(ErrorCode.UNAUTHORIZED_MEMBER);
         }
 
+        String OriginalFileName = request.fileName();
+        String extension = "";
+
+        int dotIndex = OriginalFileName.lastIndexOf('.');
+        if (dotIndex != -1) {
+            extension = OriginalFileName.substring(dotIndex);
+        }
+
         String uuid = UUID.randomUUID().toString();
-        String objectKey = "documents/" + uuid + "_" + request.fileName();
+        String objectKey = "temp/" + uuid + extension;
         String presignedUrl = s3Service.generatePresignedUrl(objectKey);
 
         return new DocumentResponse(presignedUrl, objectKey);
@@ -44,8 +57,13 @@ public class DocumentService {
     @Transactional
     public void saveDocument(String objectKey, Room room) {
         String fileName = objectKey.replaceAll("^.*/","");
+        String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
 
-        documentRepository.save(DocumentMapper.toDocument(objectKey, fileName, room));
+        String oldKey = "temp/" + encodedFileName;
+        String newKey = "documents/" + encodedFileName;
+
+        documentRepository.save(DocumentMapper.toDocument(newKey, fileName, room));
+        publisher.publishEvent(new DocumentCreateEvent(oldKey, fileName));
     }
 
 }

--- a/src/main/java/com/oronaminc/join/document/service/DocumentService.java
+++ b/src/main/java/com/oronaminc/join/document/service/DocumentService.java
@@ -1,6 +1,7 @@
 package com.oronaminc.join.document.service;
 
 
+import com.oronaminc.join.document.domain.Document;
 import com.oronaminc.join.document.event.DocumentCreateEvent;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -21,9 +22,6 @@ import com.oronaminc.join.room.domain.Room;
 
 import lombok.RequiredArgsConstructor;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +30,7 @@ public class DocumentService {
     private final DocumentRepository documentRepository;
     private final S3Service s3Service;
     private final ApplicationEventPublisher publisher;
+    private final DocumentReader documentReader;
 
     @Transactional
     public void deleteByRoomId(Long roomId) {
@@ -61,13 +60,25 @@ public class DocumentService {
     @Transactional
     public void saveDocument(String objectKey, Room room) {
         String fileName = objectKey.replaceAll("^.*/","");
-        String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
 
-        String oldKey = "temp/" + encodedFileName;
-        String newKey = "documents/" + encodedFileName;
+        String newKey = "documents/" + fileName;
 
         documentRepository.save(DocumentMapper.toDocument(newKey, fileName, room));
-        publisher.publishEvent(new DocumentCreateEvent(oldKey, fileName));
+        publisher.publishEvent(new DocumentCreateEvent(objectKey, fileName));
+    }
+
+    @Transactional
+    public void updateDocument(String objectKey, Long roomId) {
+        Document document = documentReader.getByRoomId(roomId);
+        String fileName = objectKey.replaceAll("^.*/","");
+
+        String oldKey = document.getFileUrl();
+        String newKey = "documents/" + fileName;
+
+        document.update(newKey);
+
+        s3Service.deleteFile(oldKey);
+        publisher.publishEvent(new DocumentCreateEvent(objectKey, fileName));
     }
 
 }

--- a/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
@@ -34,6 +34,9 @@ public enum ErrorCode {
 
     FILE_UPLOAD_FAILED("FILE-001", "파일 업로드에 실패하였습니다.", INTERNAL_SERVER_ERROR),
     NOT_FOUND_FILE("FILE-002", "존재하지 않는 파일입니다.", NOT_FOUND),
+    MOVEMENT_FILE_FAILED("FILE-003", "파일 이동이 실패하였습니다.", INTERNAL_SERVER_ERROR),
+    DELETE_FILE_FAILED("FILE-004", "파일 삭제에 실패하였습니다.", INTERNAL_SERVER_ERROR),
+
 
     NOT_FOUND_ROOM_QUESTION("QUESTION-001", "질문을 해당 방에서 찾을 수 없습니다.", NOT_FOUND),
     NOT_FOUND_QUESTION("QUESTION-002", "질문을 찾을 수 없습니다.", NOT_FOUND),

--- a/src/main/java/com/oronaminc/join/infra/service/S3Service.java
+++ b/src/main/java/com/oronaminc/join/infra/service/S3Service.java
@@ -6,10 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
@@ -67,5 +64,22 @@ public class S3Service {
             log.error("S3Exception: {}",e.getMessage(), e);
             return false;
         }
+    }
+
+    public void moveObject(String objectKey, String destinationKey) {
+        CopyObjectRequest copyRequest = CopyObjectRequest.builder()
+                .sourceBucket(bucket)
+                .sourceKey(objectKey)
+                .destinationBucket(bucket)
+                .destinationKey(destinationKey)
+                .build();
+        s3Client.copyObject(copyRequest);
+
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
     }
 }

--- a/src/main/java/com/oronaminc/join/infra/service/S3Service.java
+++ b/src/main/java/com/oronaminc/join/infra/service/S3Service.java
@@ -1,5 +1,6 @@
 package com.oronaminc.join.infra.service;
 
+import com.oronaminc.join.global.exception.ErrorCode;
 import com.oronaminc.join.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +51,7 @@ public class S3Service {
             }
         } catch (S3Exception e) {
             log.error("S3Exception: {}", e.getMessage(), e);
+            throw new ErrorException(ErrorCode.DELETE_FILE_FAILED);
         }
     }
 

--- a/src/main/java/com/oronaminc/join/room/service/RoomService.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomService.java
@@ -111,9 +111,9 @@ public class RoomService {
             throw new ErrorException(BAD_REQUEST_ROOM_STARTED);
         }
 
-        document.update(updateRoomRequest.documentUrl());
         room.update(updateRoomRequest);
         participantService.updateTeam(room, updateRoomRequest.teamEmail());
+        documentService.updateDocument(updateRoomRequest.documentUrl(), roomId);
     }
 
     @Transactional

--- a/src/main/java/com/oronaminc/join/room/service/RoomService.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomService.java
@@ -70,8 +70,8 @@ public class RoomService {
         Room room = RoomMapper.toRoom(createRoomRequest, code);
         roomRepository.save(room);
 
-        documentService.saveDocument(createRoomRequest.documentUrl(), room);
         participantService.savePresenterAndTeam(presenterEmail, createRoomRequest.teamEmail(), room);
+        documentService.saveDocument(createRoomRequest.documentUrl(), room);
 
         return RoomMapper.toCreateRoomResponse(room);
     }

--- a/src/main/java/com/oronaminc/join/room/service/RoomService.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomService.java
@@ -105,7 +105,6 @@ public class RoomService {
         participantService.validatePresenter(roomId, memberId);
 
         Room room = roomReader.getById(roomId);
-        Document document = documentReader.getByRoomId(roomId);
 
         if (room.getRoomStatus().equals(RoomStatus.STARTED)) {
             throw new ErrorException(BAD_REQUEST_ROOM_STARTED);


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. (작업 파일)

document/event/DocumentCreateEvent.java
document/event/DocumentEventHandler.java
document/service/DocumentService.java
infra/service/S3Service.java
room/service/RoomService.java

#### 2. (작업 내용 요약)

- 발표방 생성시 발표자료도 생성할 때 트랜잭션이 완료되면 파일 이동 로직을 수행합니다.(@TransactionEventListner 사용)
 
```java
    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
    public void handleDocumentEvent(DocumentCreateEvent event) {
        String newKey = "documents/" + event.fileName();

        try {
            s3Service.moveObject(event.objectKey(), newKey);

            log.debug("✅ S3 파일 이동 성공: {} → {}", event.objectKey(), newKey);
        } catch (Exception e) {
            log.debug("❌ S3 파일 이동 실패: {} → {}, 이유: {}", event.objectKey(), newKey, e.getMessage(), e);
        }
    }
```

- presigned url 발급 확인

<img width="985" height="537" alt="스크린샷 2025-07-17 오후 4 11 27" src="https://github.com/user-attachments/assets/15ea5657-959f-4ef0-a498-9f324054de33" />

- 발표방 생성시 발표자료도 생성
<img width="619" height="489" alt="스크린샷 2025-07-17 오후 4 11 35" src="https://github.com/user-attachments/assets/77f8627f-7ad1-47fd-98f7-3afb6bb141a0" />

- 발표자료 temp 폴더 -> documents 폴더 이동 확인
<img width="1509" height="390" alt="스크린샷 2025-07-17 오후 4 11 50" src="https://github.com/user-attachments/assets/a407b9dc-41d9-40c7-b122-ad5393ed252a" />


<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- S3에는 한글명 파일이 인코딩되어 저장돼서 서버에서 파일을 찾지 못하는현상이 발생합니다. 일단 업로드 파일명은 UUID.pdf 형식으로 저장하게끔 구현했습니다.

<br/>
