### PR TITLE
feat 답변 생성 리팩토링 및 rate limiting 추가

### DIFF
--- a/src/main/java/com/oronaminc/join/answer/dto/AnswerCreateResponse.java
+++ b/src/main/java/com/oronaminc/join/answer/dto/AnswerCreateResponse.java
@@ -10,7 +10,6 @@ import lombok.Builder;
 @Builder
 @Schema(description = "WebSocket STOMP 통신 답변 응답 DTO")
 public record AnswerCreateResponse(
-    //TODO: QuestionCreateResponse와 유사-> 둘중 하나만?
     @Schema(description = "답변이 생성될 질문 ID")
     Long questionId,
     @Schema(description = "답변 생성/삭제/수정 상태", example = "CREATE")
@@ -18,8 +17,6 @@ public record AnswerCreateResponse(
     @Schema(description = "답변 ID", example = "11")
     Long answerId,
     @Schema(description = "답변 내용", example = "답변입니다.")
-    @NotBlank(message = "답변 내용을 입력해주시기 바랍니다.")
-    @Size(max = 300, message = "답변 내용은 최대 300자까지 입력할 수 있습니다.")
     String content,
     @Schema(description = "답변 내용에 대한 공감 수", example = "23")
     int emojiCount,

--- a/src/main/java/com/oronaminc/join/answer/dto/AnswerRequest.java
+++ b/src/main/java/com/oronaminc/join/answer/dto/AnswerRequest.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "답변 생성/수정 요청 DTO")
 public record AnswerRequest(
-    //TODO: 빈값 or " " (space) 처리
     @NotBlank(message = "답변 내용을 입력해주시기 바랍니다.")
     @Size(max = 300, message = "답변 내용은 최대 300자까지 입력할 수 있습니다.")
     @Schema(description = "답변 내용", example = "답변입니다.")

--- a/src/main/java/com/oronaminc/join/answer/service/AnswerService.java
+++ b/src/main/java/com/oronaminc/join/answer/service/AnswerService.java
@@ -1,15 +1,14 @@
 package com.oronaminc.join.answer.service;
 
-import static com.oronaminc.join.global.exception.ErrorCode.BADREQUEST_DUPLICATION_ANSWER;
 
 import com.oronaminc.join.answer.dao.AnswerRepository;
 import com.oronaminc.join.answer.domain.Answer;
-import com.oronaminc.join.answer.dto.AnswerRequest;
 import com.oronaminc.join.answer.dto.AnswerGetResponse;
+import com.oronaminc.join.answer.dto.AnswerRequest;
 import com.oronaminc.join.answer.mapper.AnswerMapper;
+import com.oronaminc.join.answer.util.PermissionValidator;
 import com.oronaminc.join.emoji.domain.TargetType;
 import com.oronaminc.join.emoji.service.EmojiReader;
-import com.oronaminc.join.global.exception.ErrorException;
 import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.member.service.MemberReader;
 import com.oronaminc.join.participant.service.ParticipantService;
@@ -28,12 +27,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnswerService {
 
     private final AnswerRepository answerRepository;
-    private final ParticipantService participantService;
     private final QuestionReader questionReader;
     private final MemberReader memberReader;
     private final AnswerReader answerReader;
     private final RoomReader roomReader;
     private final EmojiReader emojiReader;
+    private final PermissionValidator permissionValidator;
 
     @Transactional
     public Answer create(Long roomId, Long memberId, Long questionId,
@@ -41,19 +40,12 @@ public class AnswerService {
 
         Member member = memberReader.getById(memberId);
         Room room = roomReader.getById(roomId);
-        Question question = questionReader.getByIdAndRoomId(questionId, roomId);
-
-        participantService.validateParticipant(member.getId(), room.getId());
-
-        if (answerReader.existsByQuestionIdAndMemberId(question.getId(), member.getId())) {
-            throw new ErrorException(BADREQUEST_DUPLICATION_ANSWER);
-        }
-
+        Question question = questionReader.getByIdAndRoomId(questionId, room.getId());
+        permissionValidator.validateAnswerCreatePermission(room.getId(), member.getId(), question);
         Answer answer = AnswerMapper.toEntity(question, member, request);
 
-        answerRepository.save(answer);
+        return answerRepository.save(answer);
 
-        return answer;
     }
 
     @Transactional
@@ -71,8 +63,8 @@ public class AnswerService {
     }
 
     @Transactional
-    public Answer update(Long answerId, AnswerRequest request) {
-        Answer answer = answerReader.getById(answerId);
+    public Answer update(Long answerId, Long memberId, AnswerRequest request) {
+        Answer answer = permissionValidator.validateAnswerUpdatePermission(answerId, memberId);
 
         answer.updataContent(request.content());
 
@@ -80,8 +72,8 @@ public class AnswerService {
     }
 
     @Transactional
-    public void delete(Long answerId) {
-        Answer answer = answerReader.getById(answerId);
+    public void delete(Long answerId, Long memberId) {
+        Answer answer = permissionValidator.validateAnswerDeletePermission(answerId, memberId);
         answerRepository.delete(answer);
     }
 

--- a/src/main/java/com/oronaminc/join/answer/util/PermissionType.java
+++ b/src/main/java/com/oronaminc/join/answer/util/PermissionType.java
@@ -1,0 +1,18 @@
+package com.oronaminc.join.answer.util;
+
+import com.oronaminc.join.global.exception.ErrorCode;
+import lombok.Getter;
+
+
+@Getter
+public enum PermissionType {
+    CREATE, DELETE;
+
+    public ErrorCode toErrorCode() {
+        return switch (this) {
+            case CREATE -> ErrorCode.UNAUTHORIZED_ROLE_ANSWER;
+            case DELETE -> ErrorCode.UNAUTHORIZED_DELETE_ANSWER;
+        };
+    }
+
+}

--- a/src/main/java/com/oronaminc/join/answer/util/PermissionValidator.java
+++ b/src/main/java/com/oronaminc/join/answer/util/PermissionValidator.java
@@ -1,8 +1,6 @@
 package com.oronaminc.join.answer.util;
 
-import static com.oronaminc.join.global.exception.ErrorCode.UNAUTHORIZED_DELETE_ANSWER;
 import static com.oronaminc.join.global.exception.ErrorCode.UNAUTHORIZED_EDIT_ANSWER;
-import static com.oronaminc.join.global.exception.ErrorCode.UNAUTHORIZED_ROLE_ANSWER;
 
 import com.oronaminc.join.answer.domain.Answer;
 import com.oronaminc.join.answer.service.AnswerReader;
@@ -22,40 +20,40 @@ public class PermissionValidator {
     private final ParticipantReader participantReader;
     private final AnswerReader answerReader;
 
-    public void validateAnswerPermission(Long roomId, Long memberId) {
-        // TODO: 생성시 조건 ( null 이면 안됨, " " 안됨, 팀원이나 발표자, 질문 작성자 본인만 생성가능 )
-        Participant participant = participantReader.getByRoomIdAndMemberId(roomId, memberId);
-        ParticipantType type = participant.getParticipantType();
-
-        if (type == ParticipantType.GUEST) {
-            throw new ErrorException(UNAUTHORIZED_ROLE_ANSWER);
-        }
+    public void validateAnswerCreatePermission(Long roomId, Long memberId, Question question) {
+        validatePermission(roomId, memberId, question, PermissionType.CREATE);
     }
 
-    public void validateAnswerUpdatePermission(Long answerId, Long memberId) {
+    public Answer validateAnswerUpdatePermission(Long answerId, Long memberId) {
         Answer answer = answerReader.getById(answerId);
 
         if (!answer.getMember().getId().equals(memberId)) {
             throw new ErrorException(UNAUTHORIZED_EDIT_ANSWER);
         }
+
+        return answer;
     }
 
-    public void validateAnswerDeletePermission(Long answerId, Long memberId) {
+    public Answer validateAnswerDeletePermission(Long answerId, Long memberId) {
         Answer answer = answerReader.getById(answerId);
-
         Room room = answer.getQuestion().getRoom();
         Question question = answer.getQuestion();
 
-        Participant participant = participantReader.getByRoomIdAndMemberId(room.getId(), memberId);
-        ParticipantType type = participant.getParticipantType();
+        validatePermission(room.getId(), memberId, question, PermissionType.DELETE);
 
+        return answer;
+    }
+
+    private void validatePermission(Long roomId, Long memberId, Question question,
+        PermissionType permissionType) {
+        Participant participant = participantReader.getByRoomIdAndMemberId(roomId, memberId);
+        ParticipantType type = participant.getParticipantType();
         boolean isQuestionWriter = question.getMember().getId().equals(memberId);
 
         if (!(isQuestionWriter || type == ParticipantType.TEAM
             || type == ParticipantType.PRESENTER)) {
-            throw new ErrorException(UNAUTHORIZED_DELETE_ANSWER);
+            throw new ErrorException(permissionType.toErrorCode());
         }
-
     }
 
 }

--- a/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
@@ -40,12 +40,12 @@ public enum ErrorCode {
     UNAUTHORIZED_EDIT_QUESTION("QUESTION-003", "작성자만 질문을 수정할 수 있습니다.", UNAUTHORIZED),
     UNAUTHORIZED_DELETE_QUESTION("QUESTION-004", "작성자 및 관리자만 질문을 삭제할 수 있습니다.", UNAUTHORIZED),
 
-    UNAUTHORIZED_ROLE_ANSWER("ANSWER-001", "팀원 또는 발표자만 댓글을 작성할 수 있습니다.", UNAUTHORIZED),
+    UNAUTHORIZED_ROLE_ANSWER("ANSWER-001", "질문 작성자 또는 팀원과 발표자만 댓글을 작성할 수 있습니다.", UNAUTHORIZED),
     NOT_FOUND_EXIST_ANSWER("ANSWER-002", "해당 질문에 대한 답변이 존재하지 않습니다.", NOT_FOUND),
     NOT_FOUND_ANSWER("ANSWER-003", "답변이 존재하지 않습니다.", NOT_FOUND),
-    BADREQUEST_DUPLICATION_ANSWER("ANSWER-004", "이미 답변한 질문입니다.", BAD_REQUEST),
-    UNAUTHORIZED_EDIT_ANSWER("ANSWER-005", "작성자가 아니면 해당 댓글을 수정할 수 없습니다.", UNAUTHORIZED),
-    UNAUTHORIZED_DELETE_ANSWER("ANSWER-006", "작성자 혹은 팀원, 발표자가 아니면 해당 댓글을 삭제할 수 없습니다.", UNAUTHORIZED),
+    UNAUTHORIZED_EDIT_ANSWER("ANSWER-004", "작성자가 아니면 해당 댓글을 수정할 수 없습니다.", UNAUTHORIZED),
+    UNAUTHORIZED_DELETE_ANSWER("ANSWER-005", "작성자 혹은 팀원, 발표자가 아니면 해당 댓글을 삭제할 수 없습니다.", UNAUTHORIZED),
+    TOO_MANY_REQUESTS_ANSWER("ANSWER-006", "잠시 후 다시 시도해주세요.", UNAUTHORIZED),
 
 
     ACCESS_DENIED_SESSION("SESSION-1201", "접근 권한이 없습니다.", FORBIDDEN),

--- a/src/main/java/com/oronaminc/join/global/ratelimit/RateLimitType.java
+++ b/src/main/java/com/oronaminc/join/global/ratelimit/RateLimitType.java
@@ -12,6 +12,14 @@ public enum RateLimitType {
             .capacity(3)
             .refillIntervally(3, Duration.ofSeconds(1))
             .build()
+    ),
+
+    CREATE_ANSWER(
+        "CREATE_ANSWER:{}:{}:{}",
+        Bandwidth.builder()
+            .capacity(5)
+            .refillIntervally(5, Duration.ofSeconds(10))
+        .build()
     );
 
     private final String format;

--- a/src/main/java/com/oronaminc/join/websocket/api/AnswerWebsocketController.java
+++ b/src/main/java/com/oronaminc/join/websocket/api/AnswerWebsocketController.java
@@ -1,5 +1,6 @@
 package com.oronaminc.join.websocket.api;
 
+import static com.oronaminc.join.global.exception.ErrorCode.TOO_MANY_REQUESTS_ANSWER;
 import static com.oronaminc.join.global.exception.ErrorCode.UNAUTHORIZED_MEMBER;
 
 import com.oronaminc.join.answer.domain.Answer;
@@ -9,8 +10,10 @@ import com.oronaminc.join.answer.dto.AnswerRequest;
 import com.oronaminc.join.answer.dto.AnswerUpdateResponse;
 import com.oronaminc.join.answer.mapper.AnswerMapper;
 import com.oronaminc.join.answer.service.AnswerService;
-import com.oronaminc.join.answer.util.PermissionValidator;
 import com.oronaminc.join.global.exception.ErrorException;
+import com.oronaminc.join.global.ratelimit.RateLimitService;
+import com.oronaminc.join.global.ratelimit.RateLimitType;
+import io.github.bucket4j.Bucket;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +30,7 @@ import org.springframework.stereotype.Controller;
 public class AnswerWebsocketController {
 
     private final AnswerService answerService;
-    private final PermissionValidator permissionValidator;
+    private final RateLimitService rateLimitService;
 
     @MessageMapping("/rooms/{roomId}/question/{questionId}/answers/create")
     @SendTo("/topic/rooms/{roomId}/answers")
@@ -39,11 +42,15 @@ public class AnswerWebsocketController {
     ) {
         Long memberId = getMemberId(principal);
 
-        permissionValidator.validateAnswerPermission(roomId, memberId);
+        Bucket bucket = rateLimitService.getBucket(RateLimitType.CREATE_ANSWER, roomId, memberId, questionId);
+
+        if (!bucket.tryConsume(1)) {
+            throw new ErrorException(TOO_MANY_REQUESTS_ANSWER);
+        }
 
         Answer answer = answerService.create(roomId, memberId, questionId, request);
 
-        log.info("답변 메세지 = {}", request.content());
+        log.info("답변 메세지 = {}", answer.getContent());
 
         return AnswerMapper.toAnswerCreateResponse(answer);
     }
@@ -58,9 +65,9 @@ public class AnswerWebsocketController {
 
         Long memberId = getMemberId(principal);
 
-        permissionValidator.validateAnswerUpdatePermission(answerId, memberId);
+        Answer answer = answerService.update(answerId, memberId, request);
 
-        Answer answer = answerService.update(answerId, request);
+        log.info("수정 메세지 = {}", answer.getContent());
 
         return AnswerMapper.toAnswerUpdateResponse(answer);
     }
@@ -68,16 +75,14 @@ public class AnswerWebsocketController {
     @MessageMapping("/answers/{answerId}/delete")
     @SendTo("/topic/rooms/{roomId}/answers")
     public AnswerDeleteResponse delete(
-        @DestinationVariable Long roomId,
-        @DestinationVariable Long questionId,
         @DestinationVariable Long answerId,
         Principal principal
     ) {
         Long memberId = getMemberId(principal);
 
-        permissionValidator.validateAnswerDeletePermission(answerId, memberId);
+        answerService.delete(answerId, memberId);
 
-        answerService.delete(answerId);
+        log.info("삭제되었습니다.");
 
         return new AnswerDeleteResponse(answerId, "DELETE");
     }

--- a/src/test/java/com/oronaminc/join/answer/api/PermissionValidTests.java
+++ b/src/test/java/com/oronaminc/join/answer/api/PermissionValidTests.java
@@ -65,13 +65,13 @@ public class PermissionValidTests {
     }
 
     @Test
-    @DisplayName("TEAM or PRESENTER가 아닌 GUEST가 답변시 예외 발생")
-    void validateAnswerPermission_fail_not_team_or_presenter() {
+    @DisplayName("TEAM or PRESENTER or 작성자가 아닌 참여자가 답변시 예외 발생")
+    void validateAnswerPermission_fail_not_team_or_presenter_orWriter() {
         // given
         given(participantReader.getByRoomIdAndMemberId(1L, 1L)).willReturn(participant);
 
         // when & then
-        assertThatThrownBy(() -> permissionValidator.validateAnswerPermission(1L, 1L))
+        assertThatThrownBy(() -> permissionValidator.validateAnswerCreatePermission(1L, 1L, question))
             .isInstanceOf(ErrorException.class)
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED_ROLE_ANSWER);
     }
@@ -84,7 +84,7 @@ public class PermissionValidTests {
             .willThrow(new ErrorException(ErrorCode.NOT_FOUND_PARTICIPANT));
 
         // when & then
-        assertThatThrownBy(() -> permissionValidator.validateAnswerPermission(1L, 1L))
+        assertThatThrownBy(() -> permissionValidator.validateAnswerCreatePermission(1L, 1L, question))
             .isInstanceOf(ErrorException.class)
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_PARTICIPANT);
     }

--- a/src/test/java/com/oronaminc/join/answer/service/AnswerServiceTests.java
+++ b/src/test/java/com/oronaminc/join/answer/service/AnswerServiceTests.java
@@ -1,7 +1,6 @@
 package com.oronaminc.join.answer.service;
 
 import static com.oronaminc.join.global.exception.ErrorCode.NOT_FOUND_ROOM;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,8 +10,8 @@ import static org.mockito.BDDMockito.willThrow;
 
 import com.oronaminc.join.answer.dao.AnswerRepository;
 import com.oronaminc.join.answer.domain.Answer;
-import com.oronaminc.join.answer.dto.AnswerRequest;
 import com.oronaminc.join.answer.dto.AnswerGetResponse;
+import com.oronaminc.join.answer.dto.AnswerRequest;
 import com.oronaminc.join.answer.util.PermissionValidator;
 import com.oronaminc.join.emoji.domain.Emoji;
 import com.oronaminc.join.emoji.domain.TargetType;
@@ -28,7 +27,6 @@ import com.oronaminc.join.participant.service.ParticipantReader;
 import com.oronaminc.join.participant.service.ParticipantService;
 import com.oronaminc.join.question.domain.Question;
 import com.oronaminc.join.question.service.QuestionReader;
-import com.oronaminc.join.question.service.QuestionService;
 import com.oronaminc.join.room.domain.Room;
 import com.oronaminc.join.room.domain.RoomStatus;
 import com.oronaminc.join.room.service.RoomReader;
@@ -62,6 +60,11 @@ public class AnswerServiceTests {
     private AnswerReader answerReader;
     @Mock
     private EmojiReader emojiReader;
+    @Mock
+    private PermissionValidator permissionValidator;
+    @Mock
+    private ParticipantReader participantReader;
+
 
     private Member mockMember;
     private Room mockRoom;
@@ -121,13 +124,12 @@ public class AnswerServiceTests {
             .question(mockQuestion)
             .emojiCount(0L)
             .version(1)
-            .content("답변입니다")
+            .content("답변입니다.")
             .build();
 
         given(memberReader.getById(1L)).willReturn(mockMember);
         given(roomReader.getById(1L)).willReturn(mockRoom);
         given(questionReader.getByIdAndRoomId(1L, 1L)).willReturn(mockQuestion);
-        given(answerReader.existsByQuestionIdAndMemberId(1L, 1L)).willReturn(false);
         given(answerRepository.save(any(Answer.class))).willReturn(answer);
 
         // when
@@ -194,11 +196,13 @@ public class AnswerServiceTests {
             .content("기존 내용")
             .build();
 
-        given(answerReader.getById(1L)).willReturn(answer);
+        given(permissionValidator.validateAnswerUpdatePermission(1L, 1L))
+            .willReturn(answer);
+
         AnswerRequest request = new AnswerRequest("수정된 내용");
 
         // when
-        Answer result = answerService.update(answer.getId(), request);
+        Answer result = answerService.update(answer.getId(), answer.getMember().getId(), request);
 
         // then
         assertThat(result.getContent()).isEqualTo("수정된 내용");
@@ -219,43 +223,27 @@ public class AnswerServiceTests {
 
     }
 
-     @Test
-     @DisplayName("존재하지 않는 room이 들어오면 예외 발생")
-     void createAnswer_room_fail() {
-         // given
-         given(memberReader.getById(1L)).willReturn(mockMember);
-         given(roomReader.getById(anyLong())).willThrow(
-             new ErrorException(NOT_FOUND_ROOM));
-         // when & then
-         assertThatThrownBy(() -> answerService.create(1L, 1L, 1L, request))
-                 .isInstanceOf(ErrorException.class)
-                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_ROOM);
-
-     }
-
     @Test
-    @DisplayName("존재하지 않는 participant가 들어오면 예외 발생")
-    void createAnswer_participant_fail() {
+    @DisplayName("존재하지 않는 room이 들어오면 예외 발생")
+    void createAnswer_room_fail() {
         // given
         given(memberReader.getById(1L)).willReturn(mockMember);
-        given(roomReader.getById(1L)).willReturn(mockRoom);
-        given(questionReader.getByIdAndRoomId(1L, 1L)).willReturn(mockQuestion);
-        willThrow(new ErrorException(ErrorCode.NOT_FOUND_PARTICIPANT))
-            .given(participantService)
-            .validateParticipant(1L, 1L);
-
+        given(roomReader.getById(anyLong())).willThrow(
+            new ErrorException(NOT_FOUND_ROOM));
         // when & then
         assertThatThrownBy(() -> answerService.create(1L, 1L, 1L, request))
             .isInstanceOf(ErrorException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_PARTICIPANT);
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_ROOM);
 
     }
+
 
     @Test
     @DisplayName("존재하지_않는_질문이_들어오면_예외_발생")
     void createAnswer_question_fail() {
         // given
         given(memberReader.getById(1L)).willReturn(mockMember);
+        given(roomReader.getById(1L)).willReturn(mockRoom);
         given(questionReader.getByIdAndRoomId(1L, 1L)).willThrow(
             new ErrorException(ErrorCode.NOT_FOUND_QUESTION));
 
@@ -266,21 +254,6 @@ public class AnswerServiceTests {
 
     }
 
-    @Test
-    @DisplayName("중복_답변_남길시_예외_발생")
-    void createAnswer_duplicate_fail() {
-        // given
-        given(memberReader.getById(1L)).willReturn(mockMember);
-        given(roomReader.getById(1L)).willReturn(mockRoom);
-        given(questionReader.getByIdAndRoomId(1L, 1L)).willReturn(mockQuestion);
-        given(answerReader.existsByQuestionIdAndMemberId(1L, 1L)).willReturn(true);
-
-        // when & then
-        assertThatThrownBy(() -> answerService.create(1L, 1L, 1L, request))
-            .isInstanceOf(ErrorException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BADREQUEST_DUPLICATION_ANSWER);
-
-    }
 }
 
 


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명


#### 1. (작업 파일)

(작업한 파일명 작성)

#### 2. (작업 내용 요약)

```java
    CREATE_ANSWER(
        "CREATE_ANSWER:{}:{}:{}",
        Bandwidth.builder()
            .capacity(5)
            .refillIntervally(5, Duration.ofSeconds(10))
        .build()
    );

``` 
- RateLimitType에 Answer부분 추가했습니다.
- 10초 동안 5번까지만 댓글 생성 가능하게 구현했습니다.  ( 제한 조건은 임의로 정했습니다 )



```java
    @MessageMapping("/rooms/{roomId}/question/{questionId}/answers/create")
    @SendTo("/topic/rooms/{roomId}/answers")
    public AnswerCreateResponse create(
        @DestinationVariable Long roomId,
        @DestinationVariable Long questionId,
        @Payload @Valid AnswerRequest request,
        Principal principal
    ) {
        Long memberId = getMemberId(principal);

        Bucket bucket = rateLimitService.getBucket(RateLimitType.CREATE_ANSWER, roomId, memberId, questionId);

        if (!bucket.tryConsume(1)) {
            throw new ErrorException(TOO_MANY_REQUESTS_ANSWER);
        }

        Answer answer = answerService.create(roomId, memberId, questionId, request);

        log.info("답변 메세지 = {}", answer.getContent());

        return AnswerMapper.toAnswerCreateResponse(answer);
    }
``` 
- 제한 조건 이상으로 생성시 TOO_MANY_REQUESTS_ANSWER 에러 나도록 구현했습니다.

<img width="1637" height="491" alt="스크린샷 2025-07-17 195630" src="https://github.com/user-attachments/assets/5d6d8904-0113-4663-bd52-829b042c4984" />

- 답변 하나만 생성 시 정상적으로 작동합니다.

<img width="1994" height="474" alt="스크린샷 2025-07-17 195703" src="https://github.com/user-attachments/assets/d7690a2d-6574-4633-99ff-1e610cde15ae" />

- 10초 동안 5번 이상 답변 생성 시 TOO_MANY_REQUESTS_ANSWER 에러 메세지 나옵니다.

<img width="1677" height="481" alt="스크린샷 2025-07-17 195908" src="https://github.com/user-attachments/assets/ffc1f6b1-d6da-4bba-b029-bad31b850ab6" />

<img width="1502" height="455" alt="스크린샷 2025-07-17 195945" src="https://github.com/user-attachments/assets/29c0f011-cb04-41bb-b15e-cfc9bd99d4e5" />

- 수정과 삭제 또한 정상적으로 동작합니다.

<br/>

## 💬 리뷰

저번 review 내용을 바탕으로  Permission 위치를 Service 비즈니스 영역에서 처리 하는 게 나을 것 같아 이와 같이 수정했습니다.




<br/>
