### PR TITLE
feat: 발표방 캐싱 및 인덱싱 적용 feat 새로운 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     testImplementation 'org.springframework.security:spring-security-test'
 
     compileOnly 'org.projectlombok:lombok'
@@ -58,6 +59,10 @@ dependencies {
 
     // bucket4j
     implementation 'com.bucket4j:bucket4j_jdk17-core:8.14.0'
+
+    // caffeine
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/oronaminc/join/emoji/service/EmojiFacade.java
+++ b/src/main/java/com/oronaminc/join/emoji/service/EmojiFacade.java
@@ -1,12 +1,14 @@
 package com.oronaminc.join.emoji.service;
 
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+
 import com.oronaminc.join.emoji.dto.EmojiRequest;
 import com.oronaminc.join.emoji.dto.EmojiResponse;
 import com.oronaminc.join.global.exception.ErrorCode;
 import com.oronaminc.join.global.exception.ErrorException;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/oronaminc/join/global/config/CacheConfig.java
+++ b/src/main/java/com/oronaminc/join/global/config/CacheConfig.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Scheduler;
 
 @EnableCaching
 @Configuration
@@ -25,6 +26,7 @@ public class CacheConfig {
                         Caffeine.newBuilder()
                                 .expireAfterWrite(cache.expireAfterWrite, TimeUnit.SECONDS)
                                 .maximumSize(cache.maximumSize)
+                                .scheduler(Scheduler.systemScheduler())
                                 .build()
                     )
                 )

--- a/src/main/java/com/oronaminc/join/global/config/CacheConfig.java
+++ b/src/main/java/com/oronaminc/join/global/config/CacheConfig.java
@@ -1,0 +1,38 @@
+package com.oronaminc.join.global.config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+                .map(cache -> new CaffeineCache(
+                        cache.cacheName,
+                        Caffeine.newBuilder()
+                                .expireAfterWrite(cache.expireAfterWrite, TimeUnit.SECONDS)
+                                .maximumSize(cache.maximumSize)
+                                .build()
+                    )
+                )
+                .toList();
+
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(caches);
+
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/oronaminc/join/global/config/CacheType.java
+++ b/src/main/java/com/oronaminc/join/global/config/CacheType.java
@@ -1,0 +1,14 @@
+package com.oronaminc.join.global.config;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CacheType {
+    ROOM_BY_ID("roomById", 300, 1000),
+    ROOM_BY_SECRET_CODE("roomBySecretCode", 300, 1000)
+    ;
+
+    public final String cacheName;
+    public final long expireAfterWrite;
+    public final long maximumSize;
+}

--- a/src/main/java/com/oronaminc/join/global/dev/DevController.java
+++ b/src/main/java/com/oronaminc/join/global/dev/DevController.java
@@ -18,11 +18,13 @@ import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.member.domain.MemberType;
 import com.oronaminc.join.member.security.MemberDetails;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@Tag(name = "개발용 API")
 @RequestMapping("/dev")
 @RequiredArgsConstructor
 public class DevController {

--- a/src/main/java/com/oronaminc/join/global/dev/HealthController.java
+++ b/src/main/java/com/oronaminc/join/global/dev/HealthController.java
@@ -1,0 +1,28 @@
+package com.oronaminc.join.global.dev;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@Tag(name = "개발용 API")
+public class HealthController {
+
+    @Operation(summary = "애플리케이션 헬스체크")
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/health")
+    public String health() {
+        return "Server is Healthy!";
+    }
+
+    @Operation(summary = "홈 헬스체크")
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/")
+    public String home() {
+        return "It's Home!";
+    }
+}

--- a/src/main/java/com/oronaminc/join/member/security/SecurityConfig.java
+++ b/src/main/java/com/oronaminc/join/member/security/SecurityConfig.java
@@ -49,16 +49,4 @@ public class SecurityConfig {
                 .logout(withDefaults())
                 .build();
     }
-    //
-    // @Bean
-    // public WebSecurityCustomizer webSecurityCustomizer() {
-    //     return web -> web.ignoring()
-    //             .requestMatchers(
-    //                     "/public/**",
-    //                     "/favicon.ico",
-    //                     "/swagger-ui/**",
-    //                     "/v3/api-docs/**"
-    //             );
-    // }
-
 }

--- a/src/main/java/com/oronaminc/join/member/security/SecurityConfig.java
+++ b/src/main/java/com/oronaminc/join/member/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import static org.springframework.security.config.Customizer.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -12,6 +13,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
+@Profile("!test")
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {

--- a/src/main/java/com/oronaminc/join/member/security/SecurityConfig.java
+++ b/src/main/java/com/oronaminc/join/member/security/SecurityConfig.java
@@ -49,5 +49,16 @@ public class SecurityConfig {
                 .logout(withDefaults())
                 .build();
     }
+    //
+    // @Bean
+    // public WebSecurityCustomizer webSecurityCustomizer() {
+    //     return web -> web.ignoring()
+    //             .requestMatchers(
+    //                     "/public/**",
+    //                     "/favicon.ico",
+    //                     "/swagger-ui/**",
+    //                     "/v3/api-docs/**"
+    //             );
+    // }
 
 }

--- a/src/main/java/com/oronaminc/join/room/domain/Room.java
+++ b/src/main/java/com/oronaminc/join/room/domain/Room.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import com.oronaminc.join.global.entity.BaseEntity;
 import com.oronaminc.join.room.dto.RoomUpdateRequest;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -33,6 +34,7 @@ public class Room extends BaseEntity {
     private String title;
     private String description;
 
+    @Column(unique = true)
     private String secretCode;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/oronaminc/join/room/dto/CreateRoomRequest.java
+++ b/src/main/java/com/oronaminc/join/room/dto/CreateRoomRequest.java
@@ -1,11 +1,11 @@
 package com.oronaminc.join.room.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 
 import org.hibernate.validator.constraints.Length;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
@@ -38,7 +38,7 @@ public record CreateRoomRequest(
 
         @NotNull
         @Size(max = 5)
-        @Schema(description = "발표방 추가한 팀원 목록", example = "{팀원1@example.com, 팀원2@example.com}")
+        @Schema(description = "발표방 추가한 팀원 목록")
         List<String> teamEmail
 ) {
 }

--- a/src/main/java/com/oronaminc/join/room/service/RoomReader.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomReader.java
@@ -4,6 +4,7 @@ import static com.oronaminc.join.global.exception.ErrorCode.*;
 
 import java.util.Optional;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import com.oronaminc.join.global.exception.ErrorException;
@@ -26,11 +27,23 @@ public class RoomReader {
                 .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
     }
 
+    @Cacheable(cacheNames = "roomById")
+    public Room getCacheById(Long roomId) {
+        return findById(roomId)
+                .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
+    }
+
     public Optional<Room> findBySecretCode(String secretCode) {
         return roomRepository.findBySecretCode(secretCode);
     }
 
     public Room getBySecretCode(String secretCode) {
+        return this.findBySecretCode(secretCode)
+                .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
+    }
+
+    @Cacheable(cacheNames = "roomBySecretCode")
+    public Room getCacheBySecretCode(String secretCode) {
         return this.findBySecretCode(secretCode)
                 .orElseThrow(() -> new ErrorException(NOT_FOUND_ROOM));
     }

--- a/src/main/java/com/oronaminc/join/room/service/RoomService.java
+++ b/src/main/java/com/oronaminc/join/room/service/RoomService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,8 +65,10 @@ public class RoomService {
     private static final int CODE_LENGTH = 6;
 
     @Transactional
-    public CreateRoomResponse createRoom(CreateRoomRequest createRoomRequest,
-            String presenterEmail) {
+    public CreateRoomResponse createRoom(
+            CreateRoomRequest createRoomRequest,
+            String presenterEmail
+    ) {
         String code = this.generateCode();
         Room room = RoomMapper.toRoom(createRoomRequest, code);
         roomRepository.save(room);
@@ -78,7 +81,7 @@ public class RoomService {
 
     @Transactional
     public JoinRoomResponse joinRoom(Long memberId, JoinRoomRequest joinRoomRequest) {
-        Room room = roomReader.getBySecretCode(joinRoomRequest.secretCode());
+        Room room = roomReader.getCacheBySecretCode(joinRoomRequest.secretCode());
         if (room.getRoomStatus().equals(RoomStatus.BEFORE_START)) {
             throw new ErrorException(UNAUTHORIZED_JOIN_ROOM);
         }
@@ -89,7 +92,7 @@ public class RoomService {
     public RoomDetailResponse getRoomDetail(Long memberId, Long roomId) {
         participantService.validateParticipant(memberId, roomId);
 
-        Room room = roomReader.getById(roomId);
+        Room room = roomReader.getCacheById(roomId);
 
         Participant presenter = participantService.getPresenter(roomId);
         List<Participant> team = participantService.getTeam(roomId);
@@ -101,6 +104,7 @@ public class RoomService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = "roomById", key = "#roomId")
     public void updateRoom(Long memberId, Long roomId, RoomUpdateRequest updateRoomRequest) {
         participantService.validatePresenter(roomId, memberId);
 
@@ -117,6 +121,7 @@ public class RoomService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = "roomById", key = "#roomId")
     public void deleteRoom(Long memberId, Long roomId) {
         participantService.validatePresenter(roomId, memberId);
 
@@ -133,6 +138,7 @@ public class RoomService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = "roomById", key = "#roomId")
     public void updateRoomStatus(Long memberId, Long roomId,
             RoomUpdateStatusRequest roomUpdateStatusRequest) {
         participantService.validatePresenter(roomId, memberId);
@@ -149,7 +155,7 @@ public class RoomService {
     @Transactional
     public RoomUpdateInfoResponse getRoomUpdateInfo(Long memberId, Long roomId) {
         participantService.validatePresenter(roomId, memberId);
-        Room room = roomReader.getById(roomId);
+        Room room = roomReader.getCacheById(roomId);
         List<Participant> team = participantService.getTeam(roomId);
         return RoomMapper.toRoomUpdateInfoResponse(room, team);
     }
@@ -171,7 +177,7 @@ public class RoomService {
             throw new ErrorException(UNAUTHORIZED_REPORT_READ);
         }
 
-        Room room = roomReader.getById(roomId);
+        Room room = roomReader.getCacheById(roomId);
         Long totalView = participantReader.countTotalView(roomId);
         Long totalQuestions = questionReader.countByRoomId(roomId);
         Long totalAnswerByQuestion = answerReader.countAnsweredQuestionsByRoomId(roomId);
@@ -218,7 +224,7 @@ public class RoomService {
 
     public RoomJoinResponse subscribeRoom(Long roomId, Long memberId) {
         participantService.validateParticipant(memberId, roomId);
-        Room room = roomReader.getById(roomId);
+        Room room = roomReader.getCacheById(roomId);
         if (!room.getRoomStatus().canSubscribeRoom) {
             throw new ErrorException(UNAUTHORIZED_SUBSCRIBE_ROOM);
         }

--- a/src/test/java/com/oronaminc/join/emoji/service/EmojiFacadeTests.java
+++ b/src/test/java/com/oronaminc/join/emoji/service/EmojiFacadeTests.java
@@ -1,6 +1,22 @@
 package com.oronaminc.join.emoji.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.oronaminc.join.answer.service.AnswerReader;
 import com.oronaminc.join.config.TestQueryDslConfig;
@@ -16,20 +32,6 @@ import com.oronaminc.join.room.dao.RoomRepository;
 import com.oronaminc.join.room.domain.Room;
 import com.oronaminc.join.room.domain.RoomStatus;
 import com.oronaminc.join.room.service.RoomReader;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 @Import({EmojiFacade.class, EmojiService.class, MemberReader.class, EmojiReader.class,
@@ -118,7 +120,7 @@ class EmojiFacadeTests {
             Room.builder()
                 .title("제목")
                 .description("내용")
-                .secretCode("123456")
+                .secretCode("654321")
                 .emojiCount(emojiCount)
                 .participantLimit(0)
                 .endedAt(LocalDateTime.now())

--- a/src/test/java/com/oronaminc/join/room/service/RoomCacheTests.java
+++ b/src/test/java/com/oronaminc/join/room/service/RoomCacheTests.java
@@ -1,0 +1,108 @@
+package com.oronaminc.join.room.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import com.oronaminc.join.member.dao.MemberRepository;
+import com.oronaminc.join.member.domain.Member;
+import com.oronaminc.join.participant.dao.ParticipantRepository;
+import com.oronaminc.join.participant.domain.Participant;
+import com.oronaminc.join.participant.domain.ParticipantType;
+import com.oronaminc.join.room.dao.RoomRepository;
+import com.oronaminc.join.room.domain.Room;
+import com.oronaminc.join.room.domain.RoomStatus;
+import com.oronaminc.join.room.domain.RoomType;
+import com.oronaminc.join.room.dto.RoomUpdateStatusRequest;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableCaching
+class RoomCacheTests {
+    @Autowired
+    private RoomService roomService;
+
+    @Autowired
+    private RoomReader roomReader;
+
+    @MockitoSpyBean
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @BeforeEach
+    void setUp() {
+        Room room = Room.builder()
+                .title("Test Room")
+                .description("Test Description")
+                .roomStatus(RoomStatus.BEFORE_START)
+                .roomType(RoomType.PUBLIC)
+                .build();
+
+        roomRepository.save(room);
+
+        Member member = Member.builder()
+                .build();
+
+        memberRepository.save(member);
+
+        Participant participant = Participant.builder()
+                .room(room)
+                .member(member)
+                .participantType(ParticipantType.PRESENTER)
+                .build();
+
+        participantRepository.save(participant);
+    }
+
+    @Test
+    void 캐시가_적용되어_두번째_조회는_DB_접근이_없어야_한다() {
+        Long roomId = 1L;
+
+        Room room = roomReader.getCacheById(roomId);
+
+        int repeat = 10;
+        for (int count = 0; count < repeat; count++) {
+            Room cacheRoom = roomReader.getCacheById(roomId);
+            assertThat(room).isSameAs(cacheRoom);
+        }
+
+        verify(roomRepository, times(1)).findById(roomId);
+
+        Cache roomCache = cacheManager.getCache("roomById");
+        Room cached = roomCache.get(roomId, Room.class);
+        assertThat(cached).isNotNull();
+    }
+
+    @Test
+    void updateRoomStatus_호출시_캐시가_삭제되어야_한다() {
+        Long roomId = 1L;
+        Long memberId = 1L;
+
+        roomReader.getCacheById(roomId);
+
+        Room cachedBefore = cacheManager.getCache("roomById").get(roomId, Room.class);
+        assertThat(cachedBefore).isNotNull();
+
+        roomService.updateRoomStatus(memberId, roomId, new RoomUpdateStatusRequest(RoomStatus.STARTED));
+
+        Room cachedAfter = cacheManager.getCache("roomById").get(roomId, Room.class);
+        assertThat(cachedAfter).isNull();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,4 +9,19 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
 
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: test-bucket
+    stack:
+      auto: false
+    credentials:
+      access-key: dummy
+      secret-key: dummy

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,10 +9,6 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
 
 cloud:
   aws:


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. (작업 파일)
/global/config/CacheConfig
/global/config/CacheType
/room/service/RoomReader
/room/service/RoomService

#### 2. (작업 내용 요약)

#### 1. 인덱싱 
<img width="445" height="627" alt="image" src="https://github.com/user-attachments/assets/1c10dc14-1adc-4d48-b318-61e7070880f1" />

발표방은 id 또는 secretCode로만 조회하기 때문에 pk인 id를 제외하고 secretCoded에 unique 설정을 하여 해당 컬럼의 인덱스를 생성했습니다.

#### 2. 캐싱
<img width="699" height="211" alt="image" src="https://github.com/user-attachments/assets/c57ddcba-952c-4580-85b2-c82bbb19ce4a" />

`CacheType`은 캐시의 설정값이라고 생각하면 편합니다.  `cacheName`은 테이블 이름, `expireAfterWrite`는 만료 시간(초), `maximumSize`는 최대 저장 공간(key-value의 최대 개수)입니다. 

<img width="660" height="485" alt="image" src="https://github.com/user-attachments/assets/4f910384-f714-4fcb-bc4f-3f1535f4efc2" />

`CacheConfig` 은 캐시 매니저를 생성합니다. `CacheType`의 값들을 통해 캐시 목록을 만들고 매니저에 set하여 생성합니다. `scheduler`는 `Caffeine`은 캐시 데이터를 삭제하지 않고 비활성화만 시키는데 이 스케줄러를 통해 캐시를 제거합니다 .

<img width="582" height="702" alt="image" src="https://github.com/user-attachments/assets/88cd7a8f-c223-4ff5-af5c-ea1f7855c19d" />

`RoomReader`에 캐시를 적용했습니다. 

먼저 캐시 사용 메서드를 따로 만든 이유는 캐시에 있는 엔티티는 영속성이 해제되어 `dirty check`를 사용할 수 없기 때문입니다. 수정 메서드에서 `dirty check`를 이용하는 경우가 많아서 따로 분리했습니다.

`service`가 아닌 `reader`에 적용한 이유는 더 활용 가능성이 높다고 생각했기 때문입니다. 다른 도메인에서 `reader`를 사용하는 경우가 많기 때문에 `reader`에 캐싱을 적용해야 더 잘 활용할 수 있을 거라 생각했습니다. 각 도메인에 맞게 적용하면 좋을 것 같습니다.

<img width="645" height="661" alt="image" src="https://github.com/user-attachments/assets/adf92b51-01a9-4cf9-8194-591ae0a63da5" />

update나 delete의 경우 발표방 데이터가 변경되는 경우이므로 캐시에서 삭제하여 잘못된 데이터가 제공되는 것을 예방했습니다.

#### 3. 캐싱 테스트
<img width="765" height="688" alt="image" src="https://github.com/user-attachments/assets/264f516c-7135-40f9-86f9-3e1a0561e73d" />

캐시가 작동되는 경우와 삭제되는 경우를 테스트했습니다.

작동되는 경우는 첫 조회(캐시 저장)와 10번 반복 조회(캐시에서 조회)를 나눠서 `repository`를 통한 조회가 1번만 일어났는지 확인하고 캐시 매니저가 캐시값을 가지고 있는지 확인했습니다.

삭제되는 경우는 평범한 조회를 통해 캐시를 저장하고 캐시 매니저가 캐시값을 가지고 있는지 확인하고 update 메서드를 실행해 캐시 매니저에서 삭제 되었는지 확인했습니다.

<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

#### `Caffeine` 캐시를 사용한 이유
처음에는 스프링에서 제공하는 기본 캐싱 기능을 사용하려고 했습니다.

하지만 직접 캐시 저장과 삭제를 관리해야 하는 단점이 있었습니다. 캐시 저장 이후 update나 delete 메서드 호출이나 스케줄러를 통한 직접 삭제가 아니면 캐시가 계속 쌓일 수 있다고 판단했습니다.

그래서 ttl 같은 기능을 제공하는 캐시를 알아보다가 EhCache와 Caffeine을 찾을 수 있었습니다.

`Caffeine`은 빠르고 간편하게 설정하고 구현할 수 있는 라이브러리입니다. 캐시의 크기, 만료 시간 등을 쉽게 설정할 수 있었습니다.
반면에 `EhCache`의 경우, 디스크 기반 캐싱 같은 저장소 옵션과 분산 캐싱 지원 등 저희 프로젝트에 비해서 무거운 라이브러리라고 판단했습니다. 

저희의 목표는 DB 조회를 줄여 성능을 높이는 것이고, TTL을 기반으로 자동으로 캐시를 관리하는 기능까지만 필요했기 때문에 가볍고 빠른 Caffeine이 적절하다고 생각했습니다.

<br/>
