### PR TITLE
feat: 카카오 로그인 재시도 로직, 방 참가자 관리 동시성 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     // caffeine
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
+    implementation 'org.springframework.retry:spring-retry:2.0.12'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/oronaminc/join/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/oronaminc/join/global/config/RestTemplateConfig.java
@@ -1,0 +1,38 @@
+package com.oronaminc.join.global.config;
+
+import java.time.Duration;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplateBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .readTimeout(Duration.ofSeconds(5))
+                .additionalInterceptors(clientHttpRequestInterceptor())
+                .build();
+    }
+
+    // 3번 재시도
+    public ClientHttpRequestInterceptor clientHttpRequestInterceptor() {
+        return (request, body, execution) -> {
+            RetryTemplate retryTemplate = new RetryTemplate();
+            retryTemplate.setRetryPolicy(new SimpleRetryPolicy(3));
+            try {
+                return retryTemplate.execute(context -> execution.execute(request, body));
+            } catch (Throwable throwable) {
+                throw new RuntimeException(throwable);
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/oronaminc/join/room/api/RoomController.java
+++ b/src/main/java/com/oronaminc/join/room/api/RoomController.java
@@ -63,7 +63,7 @@ public class RoomController {
             description = "비밀코드를 통해 해당 발표방에 참가자로 등록합니다. 시작 전 상태이면 참가할 수 없습니다.",
             security = @SecurityRequirement(name = "sessionAuth")
     )
-    @GetMapping("/code")
+    @PostMapping("/code")
     @ResponseStatus(HttpStatus.OK)
     public JoinRoomResponse joinRoom(
             @RequestBody JoinRoomRequest joinRoomRequest,

--- a/src/main/java/com/oronaminc/join/websocket/session/CurrentParticipantManager.java
+++ b/src/main/java/com/oronaminc/join/websocket/session/CurrentParticipantManager.java
@@ -23,17 +23,36 @@ public class CurrentParticipantManager {
         roomParticipants.computeIfAbsent(roomId, k -> ConcurrentHashMap.newKeySet());
     }
 
+    // public void addParticipant(Long roomId, Long memberId, int limit) {
+    //     Set<Long> participants = getRoomParticipants(roomId);
+    //
+    //     if (participants.contains(memberId)) return;
+    //
+    //     synchronized (participants) {
+    //         if (participants.size() >= limit) {
+    //             throw new ErrorException(UNAUTHORIZED_LIMIT_PARTICIPANT);
+    //         }
+    //         participants.add(memberId);
+    //     }
+    // }
+
     public void addParticipant(Long roomId, Long memberId, int limit) {
-        Set<Long> participants = getRoomParticipants(roomId);
+        roomParticipants.compute(roomId, (id, participants) -> {
+            participants = getRoomParticipants(roomId);
 
-        if (participants.contains(memberId)) return;
+            // 중복 참가자일 경우 그대로 반환 (변화 없음)
+            if (participants.contains(memberId)) {
+                return participants;
+            }
 
-        synchronized (participants) {
+            // 인원 초과 시 예외 발생
             if (participants.size() >= limit) {
                 throw new ErrorException(UNAUTHORIZED_LIMIT_PARTICIPANT);
             }
+
             participants.add(memberId);
-        }
+            return participants;
+        });
     }
 
     public void removeParticipant(Long memberId, Long roomId) {


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. (작업 파일)
/global/config/RestTemplateConfig.java
/websocket/session/CurrentParticipantManager.java

#### 2. (작업 내용 요약)

#### 1. 외부 API 재시도 설정
<img width="734" height="525" alt="image" src="https://github.com/user-attachments/assets/9ceb0bcd-760f-4e5e-94be-34ea3d01c26b" />
 
`RestTemplate` 설정입니다. 연결, 읽기 제한 시간을 5초로 설정하고, clientHttpRequestInterceptor 를 통해 3번의 재시도 로직을 추가했습니다.

#### 2. 참가자 관리 동시성 처리 수정
<img width="647" height="638" alt="image" src="https://github.com/user-attachments/assets/bb16b26c-193d-4ee7-acfb-ef458f407e76" />

기존 addParticipant 는 방의 참가자 `Set`을 찾아 `synchronized`를 걸어 동시성 처리를 진행했습니다. 멘토링에서 받은 피드백을 반영해서 `ConcurrentHashMap`의 `compute`를 사용해 참가자 불러오기, 인원 수 확인 등의 모든 로직을 `ConcurrentHashMap` 내부에서 진행하게 구현했습니다.

<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

원래는 `stomp`의 `heartbeat`를 설정하려고 했지만, 찾아보니 프론트에서도 설정해야 하는 것들이 있었습니다. 현재 API 연결도 잘 되지 않고 있어서... 일단 보류했습니다.

<br/>
