### PR TITLE
refactor,fix: 2회차 멘토링 기반 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
     // bucket4j
     implementation 'com.bucket4j:bucket4j_jdk17-core:8.14.0'
+
+    // commons-lang3
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/oronaminc/join/answer/dto/AnswerCreateResponse.java
+++ b/src/main/java/com/oronaminc/join/answer/dto/AnswerCreateResponse.java
@@ -1,6 +1,7 @@
 package com.oronaminc.join.answer.dto;
 
 import com.oronaminc.join.global.dto.WriterDto;
+import com.oronaminc.join.websocket.common.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -14,7 +15,7 @@ public record AnswerCreateResponse(
     @Schema(description = "답변이 생성될 질문 ID")
     Long questionId,
     @Schema(description = "답변 생성/삭제/수정 상태", example = "CREATE")
-    String event,
+    EventType event,
     @Schema(description = "답변 ID", example = "11")
     Long answerId,
     @Schema(description = "답변 내용", example = "답변입니다.")

--- a/src/main/java/com/oronaminc/join/answer/dto/AnswerDeleteResponse.java
+++ b/src/main/java/com/oronaminc/join/answer/dto/AnswerDeleteResponse.java
@@ -1,12 +1,13 @@
 package com.oronaminc.join.answer.dto;
 
+import com.oronaminc.join.websocket.common.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "답변 삭제 응답 DTO")
 public record AnswerDeleteResponse(
     Long answerId,
     @Schema(description = "삭제 이벤트", example = "DELETE")
-    String event
+    EventType event
 ) {
 
 }

--- a/src/main/java/com/oronaminc/join/answer/dto/AnswerUpdateResponse.java
+++ b/src/main/java/com/oronaminc/join/answer/dto/AnswerUpdateResponse.java
@@ -1,5 +1,6 @@
 package com.oronaminc.join.answer.dto;
 
+import com.oronaminc.join.websocket.common.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -8,7 +9,7 @@ import lombok.Builder;
 public record AnswerUpdateResponse(
     Long answerId,
     @Schema(description = "수정 이벤트", example = "UPDATE")
-    String event,
+    EventType event,
     @Schema(description = "수정된 내용", example = "수정된 답변입니다.")
     String content
 

--- a/src/main/java/com/oronaminc/join/answer/mapper/AnswerMapper.java
+++ b/src/main/java/com/oronaminc/join/answer/mapper/AnswerMapper.java
@@ -8,6 +8,7 @@ import com.oronaminc.join.answer.dto.AnswerUpdateResponse;
 import com.oronaminc.join.global.dto.WriterDto;
 import com.oronaminc.join.member.domain.Member;
 import com.oronaminc.join.question.domain.Question;
+import com.oronaminc.join.websocket.common.EventType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -17,7 +18,7 @@ public class AnswerMapper {
     public static AnswerCreateResponse toAnswerCreateResponse(Answer answer) {
         return AnswerCreateResponse.builder()
             .questionId(answer.getQuestion().getId())
-            .event("CREATE")
+            .event(EventType.CREATE)
             .answerId(answer.getId())
             .content(answer.getContent())
             .emojiCount(0)
@@ -51,7 +52,7 @@ public class AnswerMapper {
     public static AnswerUpdateResponse toAnswerUpdateResponse(Answer answer) {
         return AnswerUpdateResponse.builder()
             .answerId(answer.getId())
-            .event("UPDATE")
+            .event(EventType.UPDATE)
             .content(answer.getContent())
             .build();
     }

--- a/src/main/java/com/oronaminc/join/emoji/dto/EmojiResponse.java
+++ b/src/main/java/com/oronaminc/join/emoji/dto/EmojiResponse.java
@@ -1,12 +1,13 @@
 package com.oronaminc.join.emoji.dto;
 
 import com.oronaminc.join.emoji.domain.TargetType;
+import com.oronaminc.join.websocket.common.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "발표방/질문/답변 공감 생성/삭제 응답 DTO")
 public record EmojiResponse(
     @Schema(description = "이벤트 타입 (CREATE, DELETE)", example = "CREATE")
-    String event,
+    EventType event,
     @Schema(description = "공감 대상 타입 (ROOM, QUESTION, ANSWER)", example = "ROOM")
     TargetType targetType,
     @Schema(description = "공감 대상 ID", example = "1")

--- a/src/main/java/com/oronaminc/join/emoji/service/EmojiService.java
+++ b/src/main/java/com/oronaminc/join/emoji/service/EmojiService.java
@@ -11,6 +11,7 @@ import com.oronaminc.join.global.exception.ErrorException;
 import com.oronaminc.join.member.service.MemberReader;
 import com.oronaminc.join.question.service.QuestionReader;
 import com.oronaminc.join.room.service.RoomReader;
+import com.oronaminc.join.websocket.common.EventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,7 +47,7 @@ public class EmojiService {
 
         emojiCount = incrementEmojiCount(targetType, targetId);
 
-        return new EmojiResponse("CREATE", targetType, targetId, emojiCount);
+        return new EmojiResponse(EventType.CREATE, targetType, targetId, emojiCount);
 
     }
 
@@ -62,7 +63,7 @@ public class EmojiService {
         );
         emojiCount = decrementEmojiCount(targetType, targetId);
 
-        return new EmojiResponse("DELETE", targetType, targetId, emojiCount);
+        return new EmojiResponse(EventType.DELETE, targetType, targetId, emojiCount);
 
     }
 

--- a/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ErrorCode.java
@@ -31,7 +31,6 @@ public enum ErrorCode {
     UNAUTHORIZED_LIMIT_PARTICIPANT("PARTICIPANT-005", "인원이 가득 차 참가할 수 없습니다.", UNAUTHORIZED),
     UNAUTHORIZED_NOT_JOIN_ROOM("PARTICIPANT-005", "발표방에 참여하지 않았습니다. 먼저 참여해주세요.", UNAUTHORIZED),
 
-
     FILE_UPLOAD_FAILED("FILE-001", "파일 업로드에 실패하였습니다.", INTERNAL_SERVER_ERROR),
     NOT_FOUND_FILE("FILE-002", "존재하지 않는 파일입니다.", NOT_FOUND),
 
@@ -48,7 +47,6 @@ public enum ErrorCode {
     UNAUTHORIZED_EDIT_ANSWER("ANSWER-005", "작성자가 아니면 해당 댓글을 수정할 수 없습니다.", UNAUTHORIZED),
     UNAUTHORIZED_DELETE_ANSWER("ANSWER-006", "작성자 혹은 팀원, 발표자가 아니면 해당 댓글을 삭제할 수 없습니다.", UNAUTHORIZED),
 
-
     ACCESS_DENIED_SESSION("SESSION-1201", "접근 권한이 없습니다.", FORBIDDEN),
     NOT_FOUND_SESSION("SESSION-1202", "세션이 유효하지 않습니다.", UNAUTHORIZED),
     EXPIRED_SESSION("SESSION-1203", "세션이 만료되었습니다.", UNAUTHORIZED),
@@ -59,6 +57,7 @@ public enum ErrorCode {
     SOCKET_BAD_REQUEST_PATH("SOCKET-1002", "경로가 유효하지 않습니다.", BAD_REQUEST),
     SOCKET_BAD_REQUEST_MEMBER("SOCKET-1003", "회원이 유효하지 않습니다.", BAD_REQUEST),
 
+    STOMP_INVALID_DESTINATION("STOMP-001", "경로가 유효하지 않습니다.", BAD_REQUEST),
 
     CONFLICT_EMOJI("EMOJI-001", "공감 처리 중 충돌이 발생했습니다.", CONFLICT),
     NOT_FOUND_EMOJI("EMOJI-002", "해당 이모지가 존재하지 않습니다.", NOT_FOUND),

--- a/src/main/java/com/oronaminc/join/global/exception/ErrorException.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ErrorException.java
@@ -21,7 +21,7 @@ public class ErrorException extends RuntimeException {
         return new ErrorException(errorCode, errorMessage);
     }
 
-    public String createMessage(String message, Object... args) {
+    public static String createMessage(String message, Object... args) {
         return StringUtil.format(message, args);
     }
 

--- a/src/main/java/com/oronaminc/join/global/exception/ErrorException.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ErrorException.java
@@ -1,5 +1,7 @@
 package com.oronaminc.join.global.exception;
 
+import com.oronaminc.join.global.util.StringUtil;
+import java.text.MessageFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,5 +10,19 @@ import lombok.Getter;
 public class ErrorException extends RuntimeException {
 
     private final ErrorCode errorCode;
+    private final String errorMessage;
+
+    public ErrorException(ErrorCode errorCode) {
+        this(errorCode, null);
+    }
+
+    public static ErrorException of(ErrorCode errorCode, String message, Object... args) {
+        String errorMessage = createMessage(message, args);
+        return new ErrorException(errorCode, errorMessage);
+    }
+
+    public String createMessage(String message, Object... args) {
+        return StringUtil.format(message, args);
+    }
 
 }

--- a/src/main/java/com/oronaminc/join/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/oronaminc/join/global/exception/ExceptionAdvice.java
@@ -18,7 +18,7 @@ public class ExceptionAdvice {
     public ResponseEntity<ErrorResponse> handleErrorException(ErrorException ex) {
         ErrorCode errorCode = ex.getErrorCode();
 
-        log.error(errorCode.getMessage(), ex);
+        log.error("ErrorCode: {}, ErrorMessage: {}", ex.getErrorCode(), ex.getErrorMessage());
 
         HttpStatus httpStatus = switch (errorCode.getErrorStatus()) {
             case NOT_FOUND -> HttpStatus.NOT_FOUND;

--- a/src/main/java/com/oronaminc/join/participant/dao/ParticipantRepository.java
+++ b/src/main/java/com/oronaminc/join/participant/dao/ParticipantRepository.java
@@ -15,11 +15,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
-    @Query(
-        "SELECT COUNT(p) > 0 " +
-        "FROM Participant p " +
-        "WHERE p.room.id = :roomId AND p.member.id = :memberId"
-    )
+    @Query("""
+        select COUNT(p) > 0 
+        from Participant p 
+        where p.room.id = :roomId and p.member.id = :memberId
+    """)
     boolean existsByRoomIdAndMemberId(@Param("roomId") Long roomId, @Param("memberId") Long memberId);
 
     Optional<Participant> findByRoomIdAndParticipantType(Long roomId, ParticipantType participantType);
@@ -30,7 +30,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
         from Participant p
         where p.member.id = :memberId
         group by p.participantType
-        """)
+    """)
     List<ParticipantCountDto> countByMemberIdGroupByParticipantType(Long memberId);
 
     @Query("""
@@ -38,7 +38,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
         from Participant p
         join fetch p.room
         where p.member.id = :memberId
-        """)
+    """)
     Page<Participant> findByMemberId(Long memberId, Pageable pageable);
 
     @Query("""
@@ -46,7 +46,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
         from Participant p
         join fetch p.room
         where p.member.id = :memberId and p.participantType = :pType
-        """)
+    """)
     Page<Participant> findByMemberIdAndParticipantType(Long memberId, ParticipantType pType,
         Pageable pageable);
 
@@ -55,30 +55,30 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
         from Participant p
         join fetch p.room
         where p.member.id = :memberId and p.participantType != :pType
-        """)
+    """)
     Page<Participant> findByMemberIdAndParticipantTypeNot(Long memberId, ParticipantType pType,
         Pageable pageable);
 
     Optional<Participant> findByRoomIdAndMemberId( @Param("roomId") Long roomId, @Param("memberId") Long memberId );
 
     @Query("""
-        SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END 
-        FROM Participant p
-        WHERE p.room.id = :roomId
-        AND p.member.id = :memberId
-        AND (p.participantType = com.oronaminc.join.participant.domain.ParticipantType.PRESENTER
-            OR p.participantType = com.oronaminc.join.participant.domain.ParticipantType.TEAM)
+        select case when COUNT(p) > 0 then true else false end 
+        from Participant p
+        where p.room.id = :roomId
+        and p.member.id = :memberId
+        and (p.participantType = com.oronaminc.join.participant.domain.ParticipantType.PRESENTER
+            or p.participantType = com.oronaminc.join.participant.domain.ParticipantType.TEAM)
     """)
     boolean existsPresenterOrTeamByMemberId(@Param("roomId") Long roomId, @Param("memberId") Long memberId);
 
     void deleteByRoomId(Long roomId);
 
     @Query(value = """
-        SELECT COUNT(*) 
-        FROM participant
-        WHERE room_id = :roomId
-            AND exited_at IS NOT NULL 
-            AND TIMESTAMPDIFF(SECOND, created_at, exited_at) >= 30
+        select COUNT(*) 
+        from participant
+        where room_id = :roomId
+        and exited_at is not null
+        and TIMESTAMPDIFF(SECOND, created_at, exited_at) >= 30
     """, nativeQuery = true)
     Long countParticipantsStayedOver30Seconds(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/oronaminc/join/question/api/QuestionController.java
+++ b/src/main/java/com/oronaminc/join/question/api/QuestionController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -30,7 +31,7 @@ public class QuestionController {
         @RequestParam(required = false) Long lastEmojiCount,
         @RequestParam(defaultValue = "10") int size,
         @RequestParam Long memberId,
-        @RequestParam Long roomId
+        @PathVariable Long roomId
     ) {
         Slice<QuestionAssembleResponse> result = questionService.getQuestions(
             sort, lastId, lastEmojiCount, size, memberId, roomId

--- a/src/main/java/com/oronaminc/join/question/dto/QuestionCreateResponse.java
+++ b/src/main/java/com/oronaminc/join/question/dto/QuestionCreateResponse.java
@@ -2,6 +2,7 @@ package com.oronaminc.join.question.dto;
 
 
 import com.oronaminc.join.global.dto.WriterDto;
+import com.oronaminc.join.websocket.common.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.Builder;
 @Schema(description = "질문 생성 응답 DTO")
 public record QuestionCreateResponse(
     @Schema(description = "", example = "CREATE")
-    String event,
+    EventType event,
     @Schema(description = "질문 ID", example = "11")
     Long questionId,
     @Schema(description = "질문 내용", example = "질문있습니다. 질문생성DTO가 맞나요?")

--- a/src/main/java/com/oronaminc/join/question/dto/QuestionDeleteResponse.java
+++ b/src/main/java/com/oronaminc/join/question/dto/QuestionDeleteResponse.java
@@ -1,11 +1,12 @@
 package com.oronaminc.join.question.dto;
 
+import com.oronaminc.join.websocket.common.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Schema(description = "질문 삭제 응답 DTO")
 public record QuestionDeleteResponse(
-    String event,
+    EventType event,
     Long questionId
 ) {
 }

--- a/src/main/java/com/oronaminc/join/question/dto/QuestionUpdateResponse.java
+++ b/src/main/java/com/oronaminc/join/question/dto/QuestionUpdateResponse.java
@@ -1,12 +1,13 @@
 package com.oronaminc.join.question.dto;
 
+import com.oronaminc.join.websocket.common.EventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 @Schema(description = "질문 수정 응답 DTO")
 public record QuestionUpdateResponse(
-    String event,
+    EventType event,
     Long questionId,
     String content
 

--- a/src/main/java/com/oronaminc/join/question/service/QuestionService.java
+++ b/src/main/java/com/oronaminc/join/question/service/QuestionService.java
@@ -42,9 +42,7 @@ public class QuestionService {
     public Question create(Long roomId, Long memberId, QuestionRequest requestDto) {
 
         Member member = memberReader.getById(memberId);
-
         Room room = roomReader.getById(roomId);
-
         participantService.validateParticipant(memberId, roomId);
 
         Question question = QuestionMapper.toQuestion(room, member, requestDto);
@@ -116,7 +114,6 @@ public class QuestionService {
 
         return question.getId();
     }
-
 
     @Transactional
     public void deleteByRoomId(Long roomId) {

--- a/src/main/java/com/oronaminc/join/question/service/QuestionService.java
+++ b/src/main/java/com/oronaminc/join/question/service/QuestionService.java
@@ -90,7 +90,8 @@ public class QuestionService {
 
         // 작성자가 아님
         if (!question.getMember().getId().equals(memberId)) {
-            throw new ErrorException(ErrorCode.UNAUTHORIZED_EDIT_QUESTION);
+            throw ErrorException.of(ErrorCode.UNAUTHORIZED_EDIT_QUESTION,
+                "{}번 회원은 {}번 질문을 수정할 권한이 없습니다.", memberId, questionId);
         }
 
         question.updateContent(request.content());
@@ -104,13 +105,15 @@ public class QuestionService {
 
         // 참여자가 아님
         if (!participantReader.existsByRoomIdAndMemberId(roomId, memberId)) {
-            throw new ErrorException(ErrorCode.NOT_FOUND_PARTICIPANT);
+            throw ErrorException.of(ErrorCode.NOT_FOUND_PARTICIPANT,
+                "{}번 발표방에는 {}번 회원이 잠가 중이지 않습니다.", roomId, memberId);
         }
 
         // 관리자가 아님 && 작성자도 아님
         if (!participantReader.existsPresenterOrTeamByMemberId(roomId, memberId)
             && !question.getMember().getId().equals(memberId)) {
-            throw new ErrorException(ErrorCode.UNAUTHORIZED_DELETE_QUESTION);
+            throw ErrorException.of(ErrorCode.UNAUTHORIZED_DELETE_QUESTION,
+                "{}번 회원은 {}번 질문을 삭제할 권한이 없습니다.", memberId, questionId);
         }
 
         answerService.deleteByQuestion(questionId);

--- a/src/main/java/com/oronaminc/join/question/service/QuestionService.java
+++ b/src/main/java/com/oronaminc/join/question/service/QuestionService.java
@@ -81,7 +81,8 @@ public class QuestionService {
 
         // 참여자가 아님
         if (!participantReader.existsByRoomIdAndMemberId(roomId, memberId)) {
-            throw new ErrorException(ErrorCode.NOT_FOUND_PARTICIPANT);
+            throw ErrorException.of(ErrorCode.NOT_FOUND_PARTICIPANT,
+                "{}번 발표방에는 {}번 회원이 잠가 중이지 않습니다.", roomId, memberId);
         }
 
         // 작성자가 아님

--- a/src/main/java/com/oronaminc/join/question/util/QuestionMapper.java
+++ b/src/main/java/com/oronaminc/join/question/util/QuestionMapper.java
@@ -12,6 +12,7 @@ import com.oronaminc.join.question.dto.QuestionAssembleResponse;
 import com.oronaminc.join.question.dto.QuestionListResponse;
 import com.oronaminc.join.question.dto.QuestionUpdateResponse;
 import com.oronaminc.join.room.domain.Room;
+import com.oronaminc.join.websocket.common.EventType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -25,7 +26,7 @@ public class QuestionMapper {
 
     public static QuestionCreateResponse toQuestionCreateResponse (Question question) {
         return QuestionCreateResponse.builder()
-            .event("CREATE")
+            .event(EventType.CREATE)
             .questionId(question.getId())
             .content(question.getContent())
             .emojiCount(0L)
@@ -56,7 +57,7 @@ public class QuestionMapper {
 
     public static QuestionUpdateResponse toQuestionUpdateResponse(Question question) {
         return QuestionUpdateResponse.builder()
-            .event("UPDATE")
+            .event(EventType.UPDATE)
             .questionId(question.getId())
             .content(question.getContent())
             .build();
@@ -64,7 +65,7 @@ public class QuestionMapper {
 
     public static QuestionDeleteResponse toQuestionDeleteResponse(Long questionId) {
         return new QuestionDeleteResponse(
-            "DELETE",
+            EventType.DELETE,
             questionId
         );
     }

--- a/src/main/java/com/oronaminc/join/room/util/CodeGenerator.java
+++ b/src/main/java/com/oronaminc/join/room/util/CodeGenerator.java
@@ -1,21 +1,16 @@
 package com.oronaminc.join.room.util;
 
-import java.util.Random;
-
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CodeGenerator {
+
     private static final String CHAR_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    private static final Random random = new Random();
 
     public static String generateCode(int length) {
-        StringBuilder sb = new StringBuilder(length);
-        for (int i = 0; i < length; i++) {
-            int idx = random.nextInt(CHAR_POOL.length());
-            sb.append(CHAR_POOL.charAt(idx));
-        }
-        return sb.toString();
+
+        return RandomStringUtils.random(length, CHAR_POOL);
     }
 }

--- a/src/main/java/com/oronaminc/join/websocket/api/AnswerWebsocketController.java
+++ b/src/main/java/com/oronaminc/join/websocket/api/AnswerWebsocketController.java
@@ -11,6 +11,7 @@ import com.oronaminc.join.answer.mapper.AnswerMapper;
 import com.oronaminc.join.answer.service.AnswerService;
 import com.oronaminc.join.answer.util.PermissionValidator;
 import com.oronaminc.join.global.exception.ErrorException;
+import com.oronaminc.join.websocket.common.EventType;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
@@ -79,7 +80,7 @@ public class AnswerWebsocketController {
 
         answerService.delete(answerId);
 
-        return new AnswerDeleteResponse(answerId, "DELETE");
+        return new AnswerDeleteResponse(answerId, EventType.DELETE);
     }
 
     private Long getMemberId(Principal principal) {

--- a/src/main/java/com/oronaminc/join/websocket/common/EventType.java
+++ b/src/main/java/com/oronaminc/join/websocket/common/EventType.java
@@ -1,0 +1,5 @@
+package com.oronaminc.join.websocket.common;
+
+public enum EventType {
+    CREATE, UPDATE, DELETE
+}

--- a/src/main/java/com/oronaminc/join/websocket/config/ParticipantEventHandler.java
+++ b/src/main/java/com/oronaminc/join/websocket/config/ParticipantEventHandler.java
@@ -2,6 +2,7 @@ package com.oronaminc.join.websocket.config;
 
 import static com.oronaminc.join.global.exception.ErrorCode.*;
 
+import com.oronaminc.join.global.exception.ErrorCode;
 import java.security.Principal;
 import java.util.Set;
 
@@ -30,7 +31,7 @@ public class ParticipantEventHandler {
         Principal principal = accessor.getUser();
 
         if (destination == null) {
-            throw new ErrorException(SOCKET_BAD_REQUEST_PATH);
+            throw new ErrorException(STOMP_INVALID_DESTINATION);
         }
 
         if (!destination.startsWith(ROOM_PREFIX)) {
@@ -66,7 +67,7 @@ public class ParticipantEventHandler {
             String[] parts = destination.split("/");
             return Long.valueOf(parts[3]);
         } catch (Exception e) {
-            throw new ErrorException(SOCKET_BAD_REQUEST_PATH);
+            throw new ErrorException(STOMP_INVALID_DESTINATION);
         }
     }
 

--- a/src/test/java/com/oronaminc/join/emoji/service/EmojiServiceTests.java
+++ b/src/test/java/com/oronaminc/join/emoji/service/EmojiServiceTests.java
@@ -20,6 +20,7 @@ import com.oronaminc.join.question.domain.Question;
 import com.oronaminc.join.question.service.QuestionReader;
 import com.oronaminc.join.room.domain.Room;
 import com.oronaminc.join.room.service.RoomReader;
+import com.oronaminc.join.websocket.common.EventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,7 +84,7 @@ class EmojiServiceTests {
             new EmojiRequest(targetType, targetId));
 
         // then
-        assertThat(response.event()).isEqualTo("CREATE");
+        assertThat(response.event()).isEqualTo(EventType.CREATE);
         assertThat(response.targetType()).isEqualTo(targetType);
         assertThat(response.targetId()).isEqualTo(targetId);
         assertThat(response.emojiCount()).isEqualTo(emojiCount + 1);
@@ -121,7 +122,7 @@ class EmojiServiceTests {
             new EmojiRequest(targetType, targetId));
 
         // then
-        assertThat(response.event()).isEqualTo("CREATE");
+        assertThat(response.event()).isEqualTo(EventType.CREATE);
         assertThat(response.targetType()).isEqualTo(targetType);
         assertThat(response.targetId()).isEqualTo(targetId);
         assertThat(response.emojiCount()).isEqualTo(emojiCount + 1);
@@ -159,7 +160,7 @@ class EmojiServiceTests {
             new EmojiRequest(targetType, targetId));
 
         // then
-        assertThat(response.event()).isEqualTo("CREATE");
+        assertThat(response.event()).isEqualTo(EventType.CREATE);
         assertThat(response.targetType()).isEqualTo(targetType);
         assertThat(response.targetId()).isEqualTo(targetId);
         assertThat(response.emojiCount()).isEqualTo(emojiCount + 1);
@@ -228,7 +229,7 @@ class EmojiServiceTests {
             new EmojiRequest(targetType, targetId));
 
         // then
-        assertThat(response.event()).isEqualTo("DELETE");
+        assertThat(response.event()).isEqualTo(EventType.DELETE);
         assertThat(response.targetType()).isEqualTo(targetType);
         assertThat(response.targetId()).isEqualTo(targetId);
         assertThat(response.emojiCount()).isEqualTo(emojiCount - 1);
@@ -264,7 +265,7 @@ class EmojiServiceTests {
             new EmojiRequest(targetType, targetId));
 
         // then
-        assertThat(response.event()).isEqualTo("DELETE");
+        assertThat(response.event()).isEqualTo(EventType.DELETE);
         assertThat(response.targetType()).isEqualTo(targetType);
         assertThat(response.targetId()).isEqualTo(targetId);
         assertThat(response.emojiCount()).isEqualTo(emojiCount - 1);
@@ -300,7 +301,7 @@ class EmojiServiceTests {
             new EmojiRequest(targetType, targetId));
 
         // then
-        assertThat(response.event()).isEqualTo("DELETE");
+        assertThat(response.event()).isEqualTo(EventType.DELETE);
         assertThat(response.targetType()).isEqualTo(targetType);
         assertThat(response.targetId()).isEqualTo(targetId);
         assertThat(response.emojiCount()).isEqualTo(emojiCount - 1);


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#67 

#### 1. (작업 파일)

- src/main/java/com/oronaminc/join/global/exception/ErrorException.java
- src/main/java/com/oronaminc/join/question/api/QuestionController.java
- src/main/java/com/oronaminc/join/room/util/CodeGenerator.java
- src/main/java/com/oronaminc/join/websocket/common/EventType.java

#### 2. (작업 내용 요약)


#### 2회차 멘토링 기반 수정 사항

**1. 예외 발생 시 예외 메시지 구체화**

``` java
    public static ErrorException of(ErrorCode errorCode, String message, Object... args) {
        String errorMessage = createMessage(message, args);
        return new ErrorException(errorCode, errorMessage);
    }
```

기존 ErrorException에 메소드를 추가하였습니다. 필요 시 해당 메소드 사용하여서 어떤 값으로 인해 예외가 발생했는지 확인할 수 있도록 하시면 될 것 같습니다.

**2. EventType enum 추가**

event를 string으로 처리하던 것을 enum을 사용하도록 리팩토링 했습니다. 

**3. jpql 스타일 통일**

소문자 사용으로 통일시켜 놨습니다. (다수에 맞춤)


**4. commons-lang**

```java
    public static String generateCode(int length) {

        return RandomStringUtils.random(length, CHAR_POOL);
    }
```

유틸리티 클래스 사용하도록 리팩토링 했습니다.



<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- 제가 이 부분 작업 후 pr 작성까지만 해놓고 올리진 않았다는 것을 뒤늦게 알았습니다 ㅎㅎ.. 
- 추가로 QuestionController에서 roomId를 pathvariable이 아닌 requestparam으로 받고 있던 거 함께 수정했습니다!

<br/>
